### PR TITLE
chore: コード譜から小節番号表示を削除

### DIFF
--- a/src/components/ChordChart.tsx
+++ b/src/components/ChordChart.tsx
@@ -68,17 +68,6 @@ const ChordChart: React.FC<ChordChartProps> = ({ chartData }) => {
     
     return rows.map((row, rowIndex) => (
       <div key={rowIndex} className="mb-8">
-        {/* 小節番号の行 */}
-        <div className="flex mb-1">
-          {row.map((_, barIndex) => (
-            <div key={barIndex} className="flex-1 text-center">
-              <span className="text-xs text-gray-400">
-                {rowIndex * barsPerRow + barIndex + 1}
-              </span>
-            </div>
-          ))}
-        </div>
-        
         {/* コード表示エリア */}
         <div className="relative bg-white">
           {/* 下の罫線 */}


### PR DESCRIPTION
## Summary
- ChordChartコンポーネントから小節番号の行を削除
- よりシンプルで見やすいコード譜表示に改善

## 変更内容
- **ChordChart.tsx**: グレーで表示されていた小節番号の行を削除
- 11行のコードを削除してUIをシンプル化

## 理由
- 小節番号表示が視覚的にノイズとなっていた
- よりクリーンで見やすいコード譜表示を実現
- 実際の楽譜でも小節番号は通常表示されない

## Test plan
- [x] アプリが正常に起動すること
- [x] コード譜が正常に表示されること
- [x] 小節番号が表示されないこと
- [x] 他の機能に影響がないこと

🤖 Generated with [Claude Code](https://claude.ai/code)