### PR TITLE
fix: 拍子に応じた小節拍数とコード表示幅の修正

### DIFF
--- a/src/components/ChordChart.tsx
+++ b/src/components/ChordChart.tsx
@@ -89,7 +89,9 @@ const ChordChart: React.FC<ChordChartProps> = ({ chartData, onCreateNew }) => {
     );
   }
   const renderChordGrid = (section: ChordSection) => {
-    const beatsPerBar = section.beatsPerBar || 4;
+    // 拍子から正しい拍数を取得し、セクションのbeatsPerBarを優先しつつフォールバック
+    const timeSignatureBeats = displayChart.timeSignature ? parseInt(displayChart.timeSignature.split('/')[0]) : 4;
+    const beatsPerBar = section.beatsPerBar && section.beatsPerBar !== 4 ? section.beatsPerBar : timeSignatureBeats;
     const barsPerRow = 8;
     
     // コードを小節に分割

--- a/src/components/ChordChartEditor.tsx
+++ b/src/components/ChordChartEditor.tsx
@@ -11,10 +11,23 @@ const ChordChartEditor: React.FC<ChordChartEditorProps> = ({ chart, onSave, onCa
   const [editedChart, setEditedChart] = useState<ChordChart>({ ...chart });
   
   const handleBasicInfoChange = (field: keyof ChordChart, value: string | number | undefined) => {
-    setEditedChart(prev => ({
-      ...prev,
-      [field]: value
-    }));
+    setEditedChart(prev => {
+      const updated = {
+        ...prev,
+        [field]: value
+      };
+      
+      // 拍子が変更された場合、全セクションのbeatsPerBarを更新
+      if (field === 'timeSignature' && typeof value === 'string') {
+        const beatsPerBar = parseInt(value.split('/')[0]);
+        updated.sections = prev.sections?.map(section => ({
+          ...section,
+          beatsPerBar
+        })) || [];
+      }
+      
+      return updated;
+    });
   };
 
   const handleSectionChange = (sectionId: string, field: keyof ChordSection, value: string | number) => {
@@ -29,10 +42,11 @@ const ChordChartEditor: React.FC<ChordChartEditorProps> = ({ chart, onSave, onCa
   };
 
   const addSection = () => {
+    const beatsPerBar = editedChart.timeSignature ? parseInt(editedChart.timeSignature.split('/')[0]) : 4;
     const newSection: ChordSection = {
       id: `section-${Date.now()}`,
       name: '新しいセクション',
-      beatsPerBar: editedChart.timeSignature ? parseInt(editedChart.timeSignature.split('/')[0]) : 4,
+      beatsPerBar,
       chords: []
     };
     

--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -109,7 +109,7 @@ describe('storageService', () => {
       await storageService.saveChart(mockChart);
 
       expect(localforage.setItem).toHaveBeenCalledWith('chord-charts', {
-        'other-chart': { id: 'other-chart' },
+        'other-chart': { id: 'other-chart', sections: [] },
         [mockChart.id]: mockChart
       });
     });
@@ -127,7 +127,7 @@ describe('storageService', () => {
       await storageService.deleteChart(mockChart.id);
 
       expect(localforage.setItem).toHaveBeenCalledWith('chord-charts', {
-        'other-chart': { id: 'other-chart' }
+        'other-chart': { id: 'other-chart', sections: [] }
       });
     });
   });

--- a/src/utils/chordUtils.ts
+++ b/src/utils/chordUtils.ts
@@ -1,24 +1,30 @@
 import type { ChordChart, ChordSection } from '../types';
 import { v4 as uuidv4 } from 'uuid';
 
-export const createEmptyChordChart = (): Omit<ChordChart, 'id' | 'createdAt' | 'updatedAt'> => ({
-  title: '新しいコード譜',
-  artist: '',
-  key: 'C',
-  tempo: 120,
-  timeSignature: '4/4',
-  sections: [createEmptySection('イントロ')],
-  tags: [],
-  notes: ''
-});
+export const createEmptyChordChart = (): Omit<ChordChart, 'id' | 'createdAt' | 'updatedAt'> => {
+  const timeSignature = '4/4';
+  return {
+    title: '新しいコード譜',
+    artist: '',
+    key: 'C',
+    tempo: 120,
+    timeSignature,
+    sections: [createEmptySection('イントロ', timeSignature)],
+    tags: [],
+    notes: ''
+  };
+};
 
-export const createEmptySection = (name: string = 'セクション'): ChordSection => ({
-  id: uuidv4(),
-  name,
-  chords: [],
-  beatsPerBar: 4,
-  barsCount: 4
-});
+export const createEmptySection = (name: string = 'セクション', timeSignature: string = '4/4'): ChordSection => {
+  const beatsPerBar = parseInt(timeSignature.split('/')[0]);
+  return {
+    id: uuidv4(),
+    name,
+    chords: [],
+    beatsPerBar,
+    barsCount: 4
+  };
+};
 
 export const createNewChordChart = (
   data: Partial<ChordChart>
@@ -70,3 +76,17 @@ export const COMMON_TIME_SIGNATURES = ['4/4', '3/4', '2/4', '6/8', '12/8'];
 export const COMMON_SECTION_NAMES = [
   'イントロ', 'Aメロ', 'Bメロ', 'サビ', 'アウトロ', 'ブリッジ', 'ソロ', 'インタールード'
 ];
+
+// 既存データの移行処理：拍子に応じてbeatsPerBarを修正
+export const migrateChartData = (chart: ChordChart): ChordChart => {
+  const beatsPerBar = chart.timeSignature ? parseInt(chart.timeSignature.split('/')[0]) : 4;
+  
+  return {
+    ...chart,
+    sections: chart.sections?.map(section => ({
+      ...section,
+      // beatsPerBarが未定義、または4拍以外の拍子で4拍になっている場合は修正
+      beatsPerBar: (!section.beatsPerBar || (beatsPerBar !== 4 && section.beatsPerBar === 4)) ? beatsPerBar : section.beatsPerBar
+    })) || []
+  };
+};

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,6 @@
 import localforage from 'localforage';
 import type { ChordChart, ChordLibrary } from '../types';
+import { migrateChartData } from './chordUtils';
 
 const STORAGE_KEY = 'chord-charts';
 
@@ -26,7 +27,15 @@ export const storageService = {
   async loadCharts(): Promise<ChordLibrary | null> {
     try {
       const charts = await localforage.getItem<ChordLibrary>(STORAGE_KEY);
-      return charts;
+      if (!charts) return null;
+      
+      // データ移行処理：既存データのbeatsPerBarを拍子に応じて修正
+      const migratedCharts: ChordLibrary = {};
+      for (const [id, chart] of Object.entries(charts)) {
+        migratedCharts[id] = migrateChartData(chart);
+      }
+      
+      return migratedCharts;
     } catch (error) {
       console.error('Failed to load charts:', error);
       throw new Error('コード譜の読み込みに失敗しました');


### PR DESCRIPTION
## Summary

拍子に応じて小節の拍数とコードの表示幅が正しく計算されるように修正しました。

### 主な変更内容

- **拍子変更時の自動更新**: 編集画面で拍子を変更すると、全セクションの`beatsPerBar`が自動更新される
- **表示幅の正しい計算**: 拍子に応じてコードの表示幅が正しく計算される（3/4拍子では1拍=33.33%、4/4拍子では1拍=25%）
- **既存データの移行**: LocalStorageの既存データも自動的に正しい拍数に移行される
- **フォールバック処理**: セクションの`beatsPerBar`が古い値の場合、拍子から再計算される

### 修正されたファイル

- `src/components/ChordChart.tsx`: 表示時の拍数計算とコード幅計算の修正
- `src/components/ChordChartEditor.tsx`: 拍子変更時の全セクション更新処理を追加
- `src/utils/chordUtils.ts`: セクション作成時の拍数設定とデータ移行処理を追加
- `src/utils/storage.ts`: データ読み込み時の自動移行処理を追加
- `src/utils/__tests__/storage.test.ts`: 移行処理に対応したテスト修正

## Test plan

- [x] 新規コード譜作成時に拍子に応じた正しい拍数が設定される
- [x] 既存コード譜の拍子変更時に全セクションが正しく更新される
- [x] 3/4拍子でコードの表示幅が正しく計算される（1拍=33.33%、2拍=66.67%、3拍=100%）
- [x] 4/4拍子でコードの表示幅が正しく計算される（1拍=25%、2拍=50%、3拍=75%、4拍=100%）
- [x] 既存データが自動的に移行される
- [x] 全テストが通過する

🤖 Generated with [Claude Code](https://claude.ai/code)