### PR TITLE
improve: サイドバーボタンのデザインとアイコンを改善

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -46,11 +46,11 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
             <div className="flex items-center">
               <button
                 onClick={() => setSidebarOpen(!sidebarOpen)}
-                className="p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 mr-3"
+                className="p-2 rounded-md bg-gray-100 border border-gray-300 text-gray-600 hover:bg-gray-200 hover:text-gray-700 hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 mr-3 shadow-sm transition-all duration-150"
                 aria-label="サイドバーを開く"
               >
                 <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h6v12H4V6zM14 6h6v12h-6V6z" />
                 </svg>
               </button>
               <h1 className="text-xl font-semibold text-gray-900">Nekogata Score Manager</h1>


### PR DESCRIPTION
## Summary
- ハンバーガーメニューからパネル開閉アイコンに変更
- ボタンのクリック可能性を向上させるデザイン改善
- ユーザビリティの向上

## Changes
- サイドバーアイコンをパネル開閉を表現するアイコンに変更
- 背景色・ボーダー・シャドウを追加してボタンらしい見た目に
- ホバー効果とスムーズなトランジションを追加

## Test plan
- [x] アイコンが適切に表示されることを確認
- [x] ボタンがクリック可能に見えることを確認
- [x] ホバー効果が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)