### PR TITLE
feat: ヘッダーを左寄せに変更

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -118,28 +118,26 @@ const MainLayout: React.FC<MainLayoutProps> = ({ children, explorerOpen: propExp
     <div className="min-h-screen bg-slate-50">
       {/* Header */}
       <header className="bg-white shadow-sm border-b border-slate-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <div className="flex items-center">
-              <button
-                onClick={() => setExplorerOpen(!explorerOpen)}
-                className="px-3 py-2 rounded-md bg-slate-100 border border-slate-300 text-slate-600 hover:bg-slate-200 hover:text-slate-700 hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 mr-3 shadow-sm transition-all duration-150 text-sm font-medium"
-                aria-label={explorerOpen ? "Close Score Explorer" : "Open Score Explorer"}
-              >
-                {explorerOpen ? (
-                  <span className="flex items-center gap-1">
-                    <span className="text-lg font-bold">&lt;</span>
-                    <span className="text-xs">close score explorer</span>
-                  </span>
-                ) : (
-                  <span className="flex items-center gap-1">
-                    <span className="text-lg font-bold">&gt;</span>
-                    <span className="text-xs">open score explorer</span>
-                  </span>
-                )}
-              </button>
-              <h1 className="text-xl font-semibold text-slate-900">Nekogata Score Manager</h1>
-            </div>
+        <div className="px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center h-16">
+            <button
+              onClick={() => setExplorerOpen(!explorerOpen)}
+              className="px-3 py-2 rounded-md bg-slate-100 border border-slate-300 text-slate-600 hover:bg-slate-200 hover:text-slate-700 hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 mr-3 shadow-sm transition-all duration-150 text-sm font-medium"
+              aria-label={explorerOpen ? "Close Score Explorer" : "Open Score Explorer"}
+            >
+              {explorerOpen ? (
+                <span className="flex items-center gap-1">
+                  <span className="text-lg font-bold">&lt;</span>
+                  <span className="text-xs">close score explorer</span>
+                </span>
+              ) : (
+                <span className="flex items-center gap-1">
+                  <span className="text-lg font-bold">&gt;</span>
+                  <span className="text-xs">open score explorer</span>
+                </span>
+              )}
+            </button>
+            <h1 className="text-xl font-semibold text-slate-900">Nekogata Score Manager</h1>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- MainLayoutのヘッダーから中央寄せ（max-w-7xl mx-auto）を削除
- シンプルで一貫性のあるレイアウトに改善

## Changes
- src/layouts/MainLayout.tsx: ヘッダーの中央寄せクラスを削除

## Test plan
- [x] ビルドの確認
- [x] リントの確認
- [x] テストの実行

🤖 Generated with [Claude Code](https://claude.ai/code)