### PR TITLE
test: SectionEditorリファクタリング後のテストカバレッジを追加

### DIFF
--- a/src/components/__tests__/SectionCard.test.tsx
+++ b/src/components/__tests__/SectionCard.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SectionCard from '../SectionCard';
+import type { ChordSection } from '../../types';
+
+describe('SectionCard', () => {
+  const mockSection: ChordSection = {
+    id: 'section-1',
+    name: 'Test Section',
+    beatsPerBar: 4,
+    barsCount: 4,
+    chords: [
+      { name: 'C', root: 'C', duration: 4 },
+      { name: 'F', root: 'F', duration: 4 },
+      { name: 'G', root: 'G', duration: 4 }
+    ]
+  };
+
+  const defaultProps = {
+    section: mockSection,
+    selectedChords: new Set<string>(),
+    onSectionChange: vi.fn(),
+    onDeleteSection: vi.fn(),
+    onDuplicateSection: vi.fn(),
+    onCopyChordProgression: vi.fn(),
+    onPasteChordProgression: vi.fn(),
+    onReplaceChordProgression: vi.fn(),
+    onToggleSelectAllInSection: vi.fn(),
+    onChordDragEnd: vi.fn(),
+    onAddChordToSection: vi.fn(),
+    onUpdateChordInSection: vi.fn(),
+    onFinalizeChordName: vi.fn(),
+    onDeleteChordFromSection: vi.fn(),
+    onInsertLineBreakAfterChord: vi.fn(),
+    onToggleChordSelection: vi.fn(),
+  };
+
+  it('セクション名が正しく表示される', () => {
+    render(<SectionCard {...defaultProps} />);
+    
+    expect(screen.getByDisplayValue('Test Section')).toBeInTheDocument();
+  });
+
+  it('セクション名の変更が正しく動作する', async () => {
+    const user = userEvent.setup();
+    const onSectionChange = vi.fn();
+    
+    render(<SectionCard {...defaultProps} onSectionChange={onSectionChange} />);
+    
+    const nameInput = screen.getByDisplayValue('Test Section');
+    await user.type(nameInput, 'X');
+    
+    expect(onSectionChange).toHaveBeenLastCalledWith('section-1', 'name', 'Test SectionX');
+  });
+
+  it('セクション操作ボタンが表示される', () => {
+    render(<SectionCard {...defaultProps} />);
+    
+    expect(screen.getByTitle('このセクションの全選択')).toBeInTheDocument();
+    expect(screen.getByTitle('コード進行をコピー')).toBeInTheDocument();
+    expect(screen.getByTitle('クリップボードから追加')).toBeInTheDocument();
+    expect(screen.getByTitle('このセクションを複製')).toBeInTheDocument();
+    expect(screen.getByTitle('このセクションを削除')).toBeInTheDocument();
+  });
+
+  it('削除ボタンクリックで削除処理が呼ばれる', async () => {
+    const user = userEvent.setup();
+    const onDeleteSection = vi.fn();
+    
+    render(<SectionCard {...defaultProps} onDeleteSection={onDeleteSection} />);
+    
+    const deleteButton = screen.getByTitle('このセクションを削除');
+    await user.click(deleteButton);
+    
+    expect(onDeleteSection).toHaveBeenCalledWith('section-1');
+  });
+
+  it('複製ボタンクリックで複製処理が呼ばれる', async () => {
+    const user = userEvent.setup();
+    const onDuplicateSection = vi.fn();
+    
+    render(<SectionCard {...defaultProps} onDuplicateSection={onDuplicateSection} />);
+    
+    const duplicateButton = screen.getByTitle('このセクションを複製');
+    await user.click(duplicateButton);
+    
+    expect(onDuplicateSection).toHaveBeenCalledWith('section-1');
+  });
+
+  it('コピーボタンクリックでコピー処理が呼ばれる', async () => {
+    const user = userEvent.setup();
+    const onCopyChordProgression = vi.fn();
+    
+    render(<SectionCard {...defaultProps} onCopyChordProgression={onCopyChordProgression} />);
+    
+    const copyButton = screen.getByTitle('コード進行をコピー');
+    await user.click(copyButton);
+    
+    expect(onCopyChordProgression).toHaveBeenCalledWith('section-1');
+  });
+
+  it('全選択ボタンクリックで全選択処理が呼ばれる', async () => {
+    const user = userEvent.setup();
+    const onToggleSelectAllInSection = vi.fn();
+    
+    render(<SectionCard {...defaultProps} onToggleSelectAllInSection={onToggleSelectAllInSection} />);
+    
+    const selectAllButton = screen.getByTitle('このセクションの全選択');
+    await user.click(selectAllButton);
+    
+    expect(onToggleSelectAllInSection).toHaveBeenCalledWith('section-1');
+  });
+
+  it('コード追加ボタンが表示される', () => {
+    render(<SectionCard {...defaultProps} />);
+    
+    expect(screen.getByText('コード追加')).toBeInTheDocument();
+  });
+
+  it('コード追加ボタンクリックで追加処理が呼ばれる', async () => {
+    const user = userEvent.setup();
+    const onAddChordToSection = vi.fn();
+    
+    render(<SectionCard {...defaultProps} onAddChordToSection={onAddChordToSection} />);
+    
+    const addButton = screen.getByText('コード追加');
+    await user.click(addButton);
+    
+    expect(onAddChordToSection).toHaveBeenCalledWith('section-1');
+  });
+
+  it('テキスト一括入力セクションが表示される', () => {
+    render(<SectionCard {...defaultProps} />);
+    
+    expect(screen.getByText('テキストから一括入力')).toBeInTheDocument();
+  });
+
+  it('一括入力による置換が正しく動作する', async () => {
+    const user = userEvent.setup();
+    const onReplaceChordProgression = vi.fn();
+    
+    render(<SectionCard {...defaultProps} onReplaceChordProgression={onReplaceChordProgression} />);
+    
+    // detailsを開く
+    const summary = screen.getByText('テキストから一括入力');
+    await user.click(summary);
+    
+    const textInput = screen.getByPlaceholderText('C F G Am');
+    const replaceButton = screen.getByText('置換');
+    
+    await user.type(textInput, 'C F G Am');
+    await user.click(replaceButton);
+    
+    expect(onReplaceChordProgression).toHaveBeenCalledWith('section-1', 'C F G Am');
+  });
+
+  it('選択状態によってツールチップが変わる', () => {
+    const selectedChords = new Set(['section-1-0', 'section-1-1', 'section-1-2']);
+    
+    render(<SectionCard {...defaultProps} selectedChords={selectedChords} />);
+    
+    expect(screen.getByTitle('このセクションの選択をすべて解除')).toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/useChordOperations.test.ts
+++ b/src/hooks/__tests__/useChordOperations.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useChordOperations } from '../useChordOperations';
+import type { ChordChart } from '../../types';
+import * as chordUtils from '../../utils/chordUtils';
+
+// chordUtilsモジュールをモック
+vi.mock('../../utils/chordUtils', () => ({
+  extractChordRoot: vi.fn(),
+  parseOnChord: vi.fn(),
+}));
+
+vi.mock('../../utils/lineBreakHelpers', () => ({
+  createLineBreakMarker: vi.fn(() => ({ type: 'lineBreak' })),
+  isLineBreakMarker: vi.fn(() => false),
+}));
+
+describe('useChordOperations', () => {
+  let mockChart: ChordChart;
+  let mockOnUpdateChart: ReturnType<typeof vi.fn>;
+  let mockSetSelectedChords: ReturnType<typeof vi.fn>;
+  let mockSetLastSelectedChord: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockChart = {
+      id: 'test-chart',
+      title: 'Test Chart',
+      artist: 'Test Artist',
+      key: 'C',
+      tempo: 120,
+      timeSignature: '4/4',
+      sections: [
+        {
+          id: 'section-1',
+          name: 'Intro',
+          beatsPerBar: 4,
+          barsCount: 4,
+          chords: [
+            { name: 'C', root: 'C', duration: 4 },
+            { name: 'F', root: 'F', duration: 4 },
+            { name: 'G', root: 'G', duration: 4 }
+          ]
+        }
+      ],
+      createdAt: new Date(),
+      updatedAt: new Date()
+    };
+
+    mockOnUpdateChart = vi.fn();
+    mockSetSelectedChords = vi.fn();
+    mockSetLastSelectedChord = vi.fn();
+
+    vi.clearAllMocks();
+  });
+
+  const renderUseChordOperations = (selectedChords = new Set<string>(), lastSelectedChord: string | null = null) => {
+    return renderHook(() => useChordOperations({
+      chart: mockChart,
+      onUpdateChart: mockOnUpdateChart,
+      selectedChords,
+      setSelectedChords: mockSetSelectedChords,
+      lastSelectedChord,
+      setLastSelectedChord: mockSetLastSelectedChord,
+    }));
+  };
+
+  it('addChordToSectionが新しいコードを追加する', () => {
+    const { result } = renderUseChordOperations();
+
+    act(() => {
+      result.current.addChordToSection('section-1');
+    });
+
+    expect(mockOnUpdateChart).toHaveBeenCalledWith({
+      ...mockChart,
+      sections: [
+        {
+          ...mockChart.sections![0],
+          chords: [
+            ...mockChart.sections![0].chords,
+            { name: 'C', root: 'C', duration: 4 }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('updateChordInSectionがコードのフィールドを更新する', () => {
+    const { result } = renderUseChordOperations();
+
+    act(() => {
+      result.current.updateChordInSection('section-1', 0, 'name', 'Am');
+    });
+
+    expect(mockOnUpdateChart).toHaveBeenCalledWith({
+      ...mockChart,
+      sections: [
+        {
+          ...mockChart.sections![0],
+          chords: [
+            { name: 'Am', root: 'C', duration: 4 },
+            { name: 'F', root: 'F', duration: 4 },
+            { name: 'G', root: 'G', duration: 4 }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('finalizeChordNameがコード名をパースして更新する', () => {
+    const mockParseOnChord = vi.mocked(chordUtils.parseOnChord);
+    const mockExtractChordRoot = vi.mocked(chordUtils.extractChordRoot);
+    
+    mockParseOnChord.mockReturnValue({ chord: 'Am', base: 'C' });
+    mockExtractChordRoot.mockReturnValue('A');
+
+    const { result } = renderUseChordOperations();
+
+    act(() => {
+      result.current.finalizeChordName('section-1', 0, 'Am/C');
+    });
+
+    expect(mockParseOnChord).toHaveBeenCalledWith('Am/C');
+    expect(mockExtractChordRoot).toHaveBeenCalledWith('Am');
+    expect(mockOnUpdateChart).toHaveBeenCalledWith({
+      ...mockChart,
+      sections: [
+        {
+          ...mockChart.sections![0],
+          chords: [
+            { name: 'Am', root: 'A', duration: 4, base: 'C' },
+            { name: 'F', root: 'F', duration: 4 },
+            { name: 'G', root: 'G', duration: 4 }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('deleteChordFromSectionがコードを削除する', () => {
+    const { result } = renderUseChordOperations();
+
+    act(() => {
+      result.current.deleteChordFromSection('section-1', 1);
+    });
+
+    expect(mockOnUpdateChart).toHaveBeenCalledWith({
+      ...mockChart,
+      sections: [
+        {
+          ...mockChart.sections![0],
+          chords: [
+            { name: 'C', root: 'C', duration: 4 },
+            { name: 'G', root: 'G', duration: 4 }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('insertLineBreakAfterChordが改行マーカーを挿入する', () => {
+    const { result } = renderUseChordOperations();
+
+    act(() => {
+      result.current.insertLineBreakAfterChord('section-1', 0);
+    });
+
+    expect(mockOnUpdateChart).toHaveBeenCalledWith({
+      ...mockChart,
+      sections: [
+        {
+          ...mockChart.sections![0],
+          chords: [
+            { name: 'C', root: 'C', duration: 4 },
+            { type: 'lineBreak' },
+            { name: 'F', root: 'F', duration: 4 },
+            { name: 'G', root: 'G', duration: 4 }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('toggleChordSelectionが単一コードの選択状態を切り替える', () => {
+    const selectedChords = new Set<string>();
+    const { result } = renderUseChordOperations(selectedChords);
+
+    act(() => {
+      result.current.toggleChordSelection('section-1', 0);
+    });
+
+    expect(mockSetSelectedChords).toHaveBeenCalledWith(new Set(['section-1-0']));
+    expect(mockSetLastSelectedChord).toHaveBeenCalledWith('section-1-0');
+  });
+
+  it('toggleChordSelectionでShiftキーを押しながらクリックすると範囲選択する', () => {
+    const selectedChords = new Set<string>();
+    const { result } = renderUseChordOperations(selectedChords, 'section-1-0');
+
+    const mockEvent = { shiftKey: true } as React.MouseEvent;
+
+    act(() => {
+      result.current.toggleChordSelection('section-1', 2, mockEvent);
+    });
+
+    expect(mockSetSelectedChords).toHaveBeenCalledWith(
+      new Set(['section-1-0', 'section-1-1', 'section-1-2'])
+    );
+    expect(mockSetLastSelectedChord).toHaveBeenCalledWith('section-1-2');
+  });
+
+  it('既に選択されているコードをクリックすると選択解除する', () => {
+    const selectedChords = new Set(['section-1-0']);
+    const { result } = renderUseChordOperations(selectedChords);
+
+    act(() => {
+      result.current.toggleChordSelection('section-1', 0);
+    });
+
+    expect(mockSetSelectedChords).toHaveBeenCalledWith(new Set());
+    expect(mockSetLastSelectedChord).toHaveBeenCalledWith('section-1-0');
+  });
+});

--- a/src/hooks/__tests__/useSectionOperations.test.ts
+++ b/src/hooks/__tests__/useSectionOperations.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSectionOperations } from '../useSectionOperations';
+import type { ChordChart } from '../../types';
+import * as chordCopyPaste from '../../utils/chordCopyPaste';
+
+// chordCopyPasteモジュールをモック
+vi.mock('../../utils/chordCopyPaste', () => ({
+  copyChordProgressionToClipboard: vi.fn(),
+  pasteChordProgressionFromClipboard: vi.fn(),
+  textToChords: vi.fn(),
+}));
+
+describe('useSectionOperations', () => {
+  let mockChart: ChordChart;
+  let mockOnUpdateChart: ReturnType<typeof vi.fn>;
+  let mockSetSelectedChords: ReturnType<typeof vi.fn>;
+  let mockSetLastSelectedChord: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockChart = {
+      id: 'test-chart',
+      title: 'Test Chart',
+      artist: 'Test Artist',
+      key: 'C',
+      tempo: 120,
+      timeSignature: '4/4',
+      sections: [
+        {
+          id: 'section-1',
+          name: 'Intro',
+          beatsPerBar: 4,
+          barsCount: 4,
+          chords: [
+            { name: 'C', root: 'C', duration: 4 },
+            { name: 'F', root: 'F', duration: 4 }
+          ]
+        },
+        {
+          id: 'section-2',
+          name: 'Verse',
+          beatsPerBar: 4,
+          barsCount: 8,
+          chords: [
+            { name: 'Am', root: 'A', duration: 4 },
+            { name: 'G', root: 'G', duration: 4 }
+          ]
+        }
+      ],
+      createdAt: new Date(),
+      updatedAt: new Date()
+    };
+
+    mockOnUpdateChart = vi.fn();
+    mockSetSelectedChords = vi.fn();
+    mockSetLastSelectedChord = vi.fn();
+
+    vi.clearAllMocks();
+  });
+
+  const renderUseSectionOperations = () => {
+    return renderHook(() => useSectionOperations({
+      chart: mockChart,
+      onUpdateChart: mockOnUpdateChart,
+      selectedChords: new Set(),
+      setSelectedChords: mockSetSelectedChords,
+      setLastSelectedChord: mockSetLastSelectedChord,
+    }));
+  };
+
+  it('handleSectionChangeがセクションのフィールドを正しく更新する', () => {
+    const { result } = renderUseSectionOperations();
+
+    act(() => {
+      result.current.handleSectionChange('section-1', 'name', 'New Intro');
+    });
+
+    expect(mockOnUpdateChart).toHaveBeenCalledWith({
+      ...mockChart,
+      sections: [
+        { ...mockChart.sections![0], name: 'New Intro' },
+        mockChart.sections![1]
+      ]
+    });
+  });
+
+  it('addSectionが新しいセクションを追加する', () => {
+    const { result } = renderUseSectionOperations();
+
+    act(() => {
+      result.current.addSection();
+    });
+
+    expect(mockOnUpdateChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sections: expect.arrayContaining([
+          ...mockChart.sections!,
+          expect.objectContaining({
+            name: '新しいセクション',
+            beatsPerBar: 4,
+            barsCount: 4,
+            chords: []
+          })
+        ])
+      })
+    );
+  });
+
+  it('deleteSectionが指定されたセクションを削除する', () => {
+    const { result } = renderUseSectionOperations();
+
+    act(() => {
+      result.current.deleteSection('section-1');
+    });
+
+    expect(mockOnUpdateChart).toHaveBeenCalledWith({
+      ...mockChart,
+      sections: [mockChart.sections![1]]
+    });
+  });
+
+  it('duplicateSectionがセクションを複製する', () => {
+    const { result } = renderUseSectionOperations();
+
+    act(() => {
+      result.current.duplicateSection('section-1');
+    });
+
+    expect(mockOnUpdateChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sections: expect.arrayContaining([
+          mockChart.sections![0],
+          expect.objectContaining({
+            name: 'Intro (コピー)',
+            beatsPerBar: 4,
+            barsCount: 4,
+            chords: mockChart.sections![0].chords
+          }),
+          mockChart.sections![1]
+        ])
+      })
+    );
+  });
+
+  it('copyChordProgressionがクリップボードにコピーする', async () => {
+    const mockCopy = vi.mocked(chordCopyPaste.copyChordProgressionToClipboard);
+    mockCopy.mockResolvedValue(true);
+
+    const { result } = renderUseSectionOperations();
+
+    await act(async () => {
+      await result.current.copyChordProgression('section-1');
+    });
+
+    expect(mockCopy).toHaveBeenCalledWith(mockChart.sections![0].chords);
+    expect(result.current.copiedMessage).toContain('「Intro」のコード進行をコピーしました');
+  });
+
+  it('pasteChordProgressionがクリップボードからコードを追加する', async () => {
+    const mockPaste = vi.mocked(chordCopyPaste.pasteChordProgressionFromClipboard);
+    const pastedChords = [{ name: 'D', root: 'D', duration: 4 }];
+    mockPaste.mockResolvedValue(pastedChords);
+
+    const { result } = renderUseSectionOperations();
+
+    await act(async () => {
+      await result.current.pasteChordProgression('section-1');
+    });
+
+    expect(mockOnUpdateChart).toHaveBeenCalledWith({
+      ...mockChart,
+      sections: [
+        {
+          ...mockChart.sections![0],
+          chords: [...mockChart.sections![0].chords, ...pastedChords]
+        },
+        mockChart.sections![1]
+      ]
+    });
+  });
+
+  it('replaceChordProgressionがテキストからコード進行を置換する', () => {
+    const mockTextToChords = vi.mocked(chordCopyPaste.textToChords);
+    const newChords = [
+      { name: 'C', root: 'C', duration: 4 },
+      { name: 'G', root: 'G', duration: 4 }
+    ];
+    mockTextToChords.mockReturnValue(newChords);
+
+    const { result } = renderUseSectionOperations();
+
+    act(() => {
+      result.current.replaceChordProgression('section-1', 'C G');
+    });
+
+    expect(mockTextToChords).toHaveBeenCalledWith('C G');
+    expect(mockOnUpdateChart).toHaveBeenCalledWith({
+      ...mockChart,
+      sections: [
+        {
+          ...mockChart.sections![0],
+          chords: newChords
+        },
+        mockChart.sections![1]
+      ]
+    });
+  });
+
+  it('toggleSelectAllInSectionがセクション内のコードを全選択/全解除する', () => {
+    const selectedChords = new Set<string>();
+    const { result } = renderHook(() => useSectionOperations({
+      chart: mockChart,
+      onUpdateChart: mockOnUpdateChart,
+      selectedChords,
+      setSelectedChords: mockSetSelectedChords,
+      setLastSelectedChord: mockSetLastSelectedChord,
+    }));
+
+    act(() => {
+      result.current.toggleSelectAllInSection('section-1');
+    });
+
+    expect(mockSetSelectedChords).toHaveBeenCalledWith(
+      new Set(['section-1-0', 'section-1-1'])
+    );
+  });
+});


### PR DESCRIPTION
## Summary
SectionEditor.tsxの分割リファクタリング（PR #66）に伴い、新しく作成されたコンポーネントとカスタムフックのテストを追加しました。

### 追加されたテスト
#### SectionCard.test.tsx (12テスト)
- ✅ セクション名の表示・変更
- ✅ 各種操作ボタンの動作確認（削除、複製、コピー、全選択）
- ✅ コード一括入力機能
- ✅ 選択状態によるツールチップの変更

#### useSectionOperations.test.ts (8テスト)
- ✅ セクションの追加・削除・複製
- ✅ コード進行のコピー・ペースト機能
- ✅ テキストからのコード進行置換
- ✅ セクション内コードの全選択/解除

#### useChordOperations.test.ts (8テスト)
- ✅ コードの追加・編集・削除
- ✅ コード名のパース処理（onChord形式対応）
- ✅ 改行マーカーの挿入
- ✅ Shiftキーを使った範囲選択機能

### テスト結果
- 🎯 全28テストが正常に通過
- 🎯 既存のSectionEditorテストも影響なし
- 🎯 テストカバレッジが大幅に向上

## Test plan
- [x] `npm test`で全テストが通過することを確認
- [x] 新規追加した3つのテストファイルが正常に動作
- [x] 既存のテストに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)