### PR TITLE
fix: 実際のユーザーメールアドレス表示対応

### DIFF
--- a/src/components/sync/SyncSettingsDialog.tsx
+++ b/src/components/sync/SyncSettingsDialog.tsx
@@ -32,7 +32,8 @@ export const SyncSettingsDialog: React.FC<SyncSettingsDialogProps> = ({
       setIsAuthenticated(authStatus);
       
       if (authStatus) {
-        setUserEmail('user@example.com');
+        const email = await authProvider.getUserEmail();
+        setUserEmail(email || 'ユーザー情報取得失敗');
       }
       
       const lastSync = syncManager.getLastSyncTimeAsDate();
@@ -53,7 +54,9 @@ export const SyncSettingsDialog: React.FC<SyncSettingsDialogProps> = ({
       setAuthError(null);
       await authProvider.initialize();
       await authProvider.authenticate();
-      setUserEmail('user@example.com');
+      
+      const email = await authProvider.getUserEmail();
+      setUserEmail(email || 'ユーザー情報取得失敗');
       setIsAuthenticated(true);
     } catch (error) {
       setAuthError(error instanceof Error ? error.message : '認証に失敗しました');

--- a/src/components/sync/__tests__/SyncSettingsDialog.test.tsx
+++ b/src/components/sync/__tests__/SyncSettingsDialog.test.tsx
@@ -19,6 +19,7 @@ const mockAuthProvider = {
   authenticate: vi.fn(),
   signOut: vi.fn(),
   initialize: vi.fn(),
+  getUserEmail: vi.fn(),
 };
 
 describe('SyncSettingsDialog', () => {
@@ -34,6 +35,7 @@ describe('SyncSettingsDialog', () => {
     });
     
     mockAuthProvider.isAuthenticated.mockReturnValue(false);
+    mockAuthProvider.getUserEmail.mockResolvedValue('test@example.com');
     mockSyncManager.getLastSyncTimeAsDate.mockReturnValue(new Date('2024-01-01T00:00:00Z'));
   });
 
@@ -75,7 +77,7 @@ describe('SyncSettingsDialog', () => {
     
     await waitFor(() => {
       expect(screen.getByText('連携中')).toBeInTheDocument();
-      expect(screen.getByText('user@example.com')).toBeInTheDocument();
+      expect(screen.getByText('test@example.com')).toBeInTheDocument();
       expect(screen.getByText('サインアウト')).toBeInTheDocument();
     });
   });

--- a/src/utils/sync/googleAuth.ts
+++ b/src/utils/sync/googleAuth.ts
@@ -125,6 +125,30 @@ export class GoogleAuthProvider {
   getAccessToken(): string | null {
     return this.accessToken;
   }
+
+  async getUserEmail(): Promise<string | null> {
+    if (!this.accessToken) {
+      return null;
+    }
+
+    try {
+      const response = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+        headers: {
+          'Authorization': `Bearer ${this.accessToken}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch user info');
+      }
+
+      const userInfo = await response.json();
+      return userInfo.email || null;
+    } catch (error) {
+      console.error('Error fetching user email:', error);
+      return null;
+    }
+  }
   
   private saveTokenToStorage(token: string): void {
     sessionStorage.setItem('nekogata-google-token', token);


### PR DESCRIPTION
## Summary
- Google OAuth2のuserinfoエンドポイントから実際のユーザーメールアドレスを取得
- SyncSettingsDialogでハードコードされた"user@example.com"を実際のメールアドレス表示に変更

## 変更内容
- `GoogleAuthProvider.getUserEmail()`メソッド追加
- SyncSettingsDialog内でユーザーメール取得処理実装
- 認証時とダイアログ読み込み時に実際のメールアドレス表示

## Test plan
- [x] lint通過確認
- [x] build通過確認  
- [x] test通過確認
- [x] Google OAuth認証フロー動作確認
- [x] 実際のメールアドレス表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)