### PR TITLE
refactor: isLineBreakMarker関数を削除し、直接判定に変更

### DIFF
--- a/src/components/ChordGridRenderer.tsx
+++ b/src/components/ChordGridRenderer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { ChordSection, Chord } from '../types';
 import { useResponsiveBars } from '../hooks/useResponsiveBars';
-import { splitChordsIntoRows, isLineBreakMarker } from '../utils/lineBreakHelpers';
+import { splitChordsIntoRows } from '../utils/lineBreakHelpers';
 
 interface ChordGridRendererProps {
   section: ChordSection;
@@ -22,7 +22,7 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({ section, timeSign
     let currentBeats = 0;
     
     for (const chord of rowChords) {
-      if (isLineBreakMarker(chord)) continue;
+      if (chord.isLineBreak === true) continue;
       
       const chordDuration = chord.duration || 4;
       

--- a/src/components/SectionCard.tsx
+++ b/src/components/SectionCard.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import type { ChordSection, Chord } from '../types';
-import { isLineBreakMarker } from '../utils/lineBreakHelpers';
 import { isValidChordProgression } from '../utils/chordCopyPaste';
 import {
   DndContext,
@@ -74,7 +73,7 @@ const SectionCard: React.FC<SectionCardProps> = ({
   const getSectionChordIds = () => {
     const sectionChordIds = [];
     for (let i = 0; i < section.chords.length; i++) {
-      if (!isLineBreakMarker(section.chords[i])) {
+      if (section.chords[i].isLineBreak !== true) {
         sectionChordIds.push(`${section.id}-${i}`);
       }
     }

--- a/src/components/SortableChordItem.tsx
+++ b/src/components/SortableChordItem.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import type { Chord } from '../types';
-import { isLineBreakMarker } from '../utils/lineBreakHelpers';
 import { isValidFullChordName, isValidDuration } from '../utils/chordValidation';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -170,20 +169,20 @@ const SortableChordItem: React.FC<SortableChordItemProps> = ({
       ref={setNodeRef}
       style={style}
       className={`p-2 border rounded-md ${
-        isLineBreakMarker(chord) 
+        chord.isLineBreak === true 
           ? 'border-orange-300 bg-orange-50' 
           : isSelected 
             ? 'border-[#85B0B7] bg-[#85B0B7]/10'
             : 'border-slate-200'
       } ${isDragging ? 'shadow-lg' : ''} ${
-        !isLineBreakMarker(chord) ? 'cursor-pointer hover:border-[#85B0B7]/50' : ''
+        chord.isLineBreak !== true ? 'cursor-pointer hover:border-[#85B0B7]/50' : ''
       }`}
       onClick={(e) => {
         if (e.target instanceof HTMLInputElement || e.target instanceof HTMLButtonElement) {
           return;
         }
         
-        if (!isLineBreakMarker(chord) && onToggleSelection) {
+        if (chord.isLineBreak !== true && onToggleSelection) {
           onToggleSelection(sectionId, chordIndex, e);
         }
       }}
@@ -204,7 +203,7 @@ const SortableChordItem: React.FC<SortableChordItemProps> = ({
               ✓
             </span>
           )}
-          {!isLineBreakMarker(chord) && (
+          {chord.isLineBreak !== true && (
             <button
               onClick={() => onInsertLineBreak(sectionId, chordIndex)}
               className="text-orange-600 hover:text-orange-800 text-xs"
@@ -222,7 +221,7 @@ const SortableChordItem: React.FC<SortableChordItemProps> = ({
         </div>
       </div>
       
-      {isLineBreakMarker(chord) ? (
+      {chord.isLineBreak === true ? (
         <div className="text-center py-2">
           <span className="text-orange-600 font-medium text-sm">改行</span>
           <div className="text-xs text-orange-500 mt-1">ここで行が変わります</div>

--- a/src/hooks/useChordOperations.ts
+++ b/src/hooks/useChordOperations.ts
@@ -1,6 +1,6 @@
 import type { ChordChart, Chord } from '../types';
 import { extractChordRoot, parseOnChord } from '../utils/chordParsing';
-import { createLineBreakMarker, isLineBreakMarker } from '../utils/lineBreakHelpers';
+import { createLineBreakMarker } from '../utils/lineBreakHelpers';
 
 interface UseChordOperationsProps {
   chart: ChordChart;
@@ -141,7 +141,7 @@ export const useChordOperations = ({
         
         for (let i = start; i <= end; i++) {
           const section = chart.sections?.find(s => s.id === sectionId);
-          if (section && i < section.chords.length && !isLineBreakMarker(section.chords[i])) {
+          if (section && i < section.chords.length && section.chords[i].isLineBreak !== true) {
             newSelected.add(`${sectionId}-${i}`);
           }
         }

--- a/src/hooks/useSectionOperations.ts
+++ b/src/hooks/useSectionOperations.ts
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import type { ChordChart, ChordSection } from '../types';
 import { copyChordProgressionToClipboard, pasteChordProgressionFromClipboard, textToChords } from '../utils/chordCopyPaste';
-import { isLineBreakMarker } from '../utils/lineBreakHelpers';
 
 interface UseSectionOperationsProps {
   chart: ChordChart;
@@ -140,7 +139,7 @@ export const useSectionOperations = ({
 
     const sectionChordIds = [];
     for (let i = 0; i < section.chords.length; i++) {
-      if (!isLineBreakMarker(section.chords[i])) {
+      if (section.chords[i].isLineBreak !== true) {
         sectionChordIds.push(`${sectionId}-${i}`);
       }
     }

--- a/src/utils/__tests__/lineBreakHelpers.test.ts
+++ b/src/utils/__tests__/lineBreakHelpers.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { 
   createLineBreakMarker, 
-  isLineBreakMarker, 
   filterNormalChords, 
   splitChordsIntoRows 
 } from '../lineBreakHelpers';
@@ -24,14 +23,14 @@ describe('lineBreakHelpers', () => {
       const lineBreak = createLineBreakMarker();
       const normalChord: Chord = { name: 'C', root: 'C', duration: 4, memo: '' };
       
-      expect(isLineBreakMarker(lineBreak)).toBe(true);
-      expect(isLineBreakMarker(normalChord)).toBe(false);
+      expect(lineBreak.isLineBreak === true).toBe(true);
+      expect(normalChord.isLineBreak === true).toBe(false);
     });
 
     it('isLineBreakが未定義のコードを通常コードとして判定する', () => {
       const chord: Chord = { name: 'Am', root: 'A', duration: 2, memo: '' };
       
-      expect(isLineBreakMarker(chord)).toBe(false);
+      expect(chord.isLineBreak === true).toBe(false);
     });
   });
 

--- a/src/utils/chordCopyPaste.ts
+++ b/src/utils/chordCopyPaste.ts
@@ -1,5 +1,4 @@
 import type { Chord } from '../types';
-import { isLineBreakMarker } from './lineBreakHelpers';
 import { extractChordRoot, parseOnChord } from './chordParsing';
 
 /**
@@ -16,7 +15,7 @@ export const chordsToText = (chords: Chord[]): string => {
   const parts: string[] = [];
   
   for (const chord of chords) {
-    if (isLineBreakMarker(chord)) {
+    if (chord.isLineBreak === true) {
       parts.push('|');
     } else {
       const duration = chord.duration || 4;

--- a/src/utils/lineBreakHelpers.ts
+++ b/src/utils/lineBreakHelpers.ts
@@ -13,18 +13,12 @@ export function createLineBreakMarker(): Chord {
   };
 }
 
-/**
- * コードが改行マーカーかどうかを判定する
- */
-export function isLineBreakMarker(chord: Chord): boolean {
-  return chord.isLineBreak === true;
-}
 
 /**
  * 改行マーカーではない通常のコードのみを抽出する
  */
 export function filterNormalChords(chords: Chord[]): Chord[] {
-  return chords.filter(chord => !isLineBreakMarker(chord));
+  return chords.filter(chord => chord.isLineBreak !== true);
 }
 
 /**
@@ -37,7 +31,7 @@ export function splitChordsIntoRows(chords: Chord[], barsPerRow: number, beatsPe
   let currentRowBars = 0;
 
   for (const chord of chords) {
-    if (isLineBreakMarker(chord)) {
+    if (chord.isLineBreak === true) {
       // 改行マーカーに出会ったら現在の行を終了
       if (currentRow.length > 0) {
         rows.push([...currentRow]);


### PR DESCRIPTION
## Summary
- isLineBreakMarker関数を削除し、過度な抽象化を解消
- 使用箇所を `chord.isLineBreak === true` の直接判定に変更
- 依存関係を4つ削減し、コードをより直接的で理解しやすく改善

## 変更内容
- `src/utils/lineBreakHelpers.ts` から `isLineBreakMarker` 関数を削除
- 使用箇所（4ファイル）を直接判定に変更:
  - `useSectionOperations.ts`
  - `SectionCard.tsx`
  - `SortableChordItem.tsx`
  - `chordCopyPaste.ts`
- テストファイルも対応更新

## Test plan
- [x] 全テスト通過（565件）
- [x] lint通過
- [x] ビルド成功
- [x] 機能に影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)