### PR TITLE
fix: Google Drive認証スコープを修正してフォルダ作成権限を追加

### DIFF
--- a/src/utils/sync/googleAuth.ts
+++ b/src/utils/sync/googleAuth.ts
@@ -34,7 +34,7 @@ export class GoogleAuthProvider {
   private isInitialized = false;
   
   private readonly CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID || '';
-  private readonly SCOPES = 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/userinfo.email';
+  private readonly SCOPES = 'https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/userinfo.email';
   
   private constructor() {}
   


### PR DESCRIPTION
## Summary
- Google Drive認証スコープを`drive.file`から`drive`に変更
- フォルダ作成・検索に必要な権限を付与
- 「Google Driveへのアクセス権限がありません」エラーを解決

## 変更内容
- `googleAuth.ts`の`SCOPES`を変更
  - Before: `https://www.googleapis.com/auth/drive.file`
  - After: `https://www.googleapis.com/auth/drive`

## 理由
- `drive.file`スコープは作成したファイルのみアクセス可能
- フォルダ作成・検索には`drive`スコープが必要
- アプリフォルダの自動作成機能に必要な権限

## Test plan
- [x] テスト実行（565件全て成功）
- [x] Lintチェック合格
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.ai/code)