### PR TITLE
fix: Google Drive multipartリクエストの改行文字エンコーディングを修正

### DIFF
--- a/src/utils/sync/googleDriveAdapter.ts
+++ b/src/utils/sync/googleDriveAdapter.ts
@@ -216,8 +216,8 @@ export class GoogleDriveSyncAdapter implements ISyncAdapter {
     if (!token) throw new Error('Not authenticated');
     
     const boundary = '-------314159265358979323846';
-    const delimiter = "\\r\\n--" + boundary + "\\r\\n";
-    const closeDelim = "\\r\\n--" + boundary + "--";
+    const delimiter = "\r\n--" + boundary + "\r\n";
+    const closeDelim = "\r\n--" + boundary + "--";
     
     const metadata = {
       name: fileName,
@@ -227,10 +227,10 @@ export class GoogleDriveSyncAdapter implements ISyncAdapter {
     
     const multipartRequestBody =
       delimiter +
-      'Content-Type: application/json\\r\\n\\r\\n' +
+      'Content-Type: application/json\r\n\r\n' +
       JSON.stringify(metadata) +
       delimiter +
-      'Content-Type: application/json\\r\\n\\r\\n' +
+      'Content-Type: application/json\r\n\r\n' +
       JSON.stringify(content, null, 2) +
       closeDelim;
     


### PR DESCRIPTION
## Summary
- Google Drive同期時の"Failed to Fetch"エラーを修正
- multipartリクエストボディの改行文字エンコーディング問題を解決

## 問題
Google Drive同期でファイルアップロード時に"Failed to Fetch"エラーが発生していた。ネットワークログの分析により、multipartボディ内の改行文字が文字列リテラル `\\r\\n` として送信されており、Google Drive APIが正しく解析できないことが原因と判明。

## 修正内容
- `googleDriveAdapter.ts`内のmultipartボディ生成部分で改行文字を修正
- `\\r\\n` → `\r\n` に変更
- HTTPリクエストボディがRFC準拠の正しい形式になった

## Test plan
- [x] 全テスト実行（565件パス）
- [x] ビルド成功
- [ ] 実際のGoogle Drive同期動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)