### PR TITLE
fix: Google Drive手動同期で空データが送信される問題を修正

### DIFF
--- a/src/components/sync/SyncSettingsDialog.tsx
+++ b/src/components/sync/SyncSettingsDialog.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { SyncManager } from '../../utils/sync/syncManager';
 import { GoogleAuthProvider } from '../../utils/sync/googleAuth';
 import { useSyncStore } from '../../stores/syncStore';
+import { useChartManagement } from '../../hooks/useChartManagement';
 import type { SyncConfig } from '../../types/sync';
 
 interface SyncSettingsDialogProps {
@@ -17,6 +18,7 @@ export const SyncSettingsDialog: React.FC<SyncSettingsDialogProps> = ({
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
   
+  const { charts } = useChartManagement();
   const { 
     isSyncing, 
     lastSyncTime, 
@@ -95,7 +97,7 @@ export const SyncSettingsDialog: React.FC<SyncSettingsDialogProps> = ({
     
     try {
       clearSyncError();
-      await sync([]);
+      await sync(Object.values(charts));
     } catch (error) {
       console.error('Manual sync failed:', error);
     }


### PR DESCRIPTION
## Summary
- Google Drive手動同期時に空データ（[]と{}）が送信される問題を修正
- 実際のローカルチャートデータが正しく同期されるように改善

## 問題
手動同期ボタンを押すと、SyncSettingsDialog.tsxの98行目で`sync([])`として空の配列を渡していたため、Google Driveに以下の空データが送信されていた：
- charts.json: `[]` (2バイト)
- sync-metadata.json: `{}` (2バイト)

## 修正内容
- `useChartManagement`フックをインポートしてローカルデータを取得
- `sync(Object.values(charts))`で実際のChordChart[]を送信
- 手動同期で正常にローカルデータがGoogle Driveに反映される

## Test plan
- [x] 全テスト実行（559/565件パス、6件はBpmIndicator関連の既知問題）
- [x] リント通過
- [x] ビルド成功
- [ ] 実際の手動同期動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)