### PR TITLE
debug: 手動同期結果の詳細ログを追加

### DIFF
--- a/src/hooks/useChartSync.ts
+++ b/src/hooks/useChartSync.ts
@@ -19,8 +19,11 @@ export const useChartSync = () => {
       const result = await syncStore.sync(charts, onConflict);
       
       // 成功時にマージ済みデータを適用
+      console.log(`[SYNC] Manual sync result:`, { success: result.success, hasCharts: !!result.mergedCharts, chartCount: result.mergedCharts?.length });
       if (result.success && result.mergedCharts) {
         await chordChartStore.applySyncedCharts(result.mergedCharts);
+      } else {
+        console.log(`[SYNC] Manual sync - not applying charts:`, { success: result.success, mergedCharts: result.mergedCharts });
       }
       
       return result;


### PR DESCRIPTION
## Summary
同期完了後に `applySyncedCharts` が呼ばれない問題を調査するため、手動同期の詳細ログを追加。

## 問題の状況
- ログが `[SYNC] Merged 7 charts for push` で途切れている
- `[SYNC] Applying X synced charts to local storage` が出力されない
- リモート7件がローカル5件に反映されない

## 調査内容
以下のログを追加：
- `result.success` の値
- `result.mergedCharts` の存在有無
- `result.mergedCharts` の配列長

## 期待される出力
```
[SYNC] Manual sync result: { success: true, hasCharts: true, chartCount: 7 }
[SYNC] Applying 7 synced charts to local storage
```

または問題がある場合：
```
[SYNC] Manual sync result: { success: false, hasCharts: false, chartCount: undefined }
[SYNC] Manual sync - not applying charts: { success: false, mergedCharts: undefined }
```

🤖 Generated with [Claude Code](https://claude.ai/code)