### PR TITLE
TODO管理運用改善: 完了タスクの即時移行ルール追加

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,41 +1,11 @@
 # TODO
 
-> 📝 **注意**: 完了済みのタスクは [TODO_DONE.md](./TODO_DONE.md) に移動されました。
+> 📝 **運用ルール**: 
+> - 完了したタスクは即座に [TODO_DONE.md](./TODO_DONE.md) に移動する
+> - タスクを完了したらすぐに該当行を削除してTODO_DONE.mdに追記する
 
 ## 次期実装予定の機能
 
-### 最優先機能: Google Drive同期
-- [x] **複数環境でのスコア同期機能** (推定工数: 2-3週間)
-  - [x] 基盤層実装
-    - [x] Google API Console設定 (プロジェクト作成、OAuth 2.0設定) ※.env.exampleファイル作成済み
-    - [x] 認証フロー実装 (GoogleAuthProvider、トークン管理)
-    - [x] 同期アダプター層 (ISyncAdapter、GoogleDriveSyncAdapter)
-  - [x] 同期ロジック実装
-    - [x] タイムスタンプ管理 (lastSyncedAt、lastModifiedAt、deviceId)
-    - [x] コンフリクト検出 (後勝ち戦略、警告表示)
-    - [x] 同期実行フロー (pull → compare → warn → push)
-  - [x] UI/UX実装
-    - [x] 同期状態表示 (SyncStatusIndicator、最終同期時刻)
-    - [x] コンフリクト警告ダイアログ (上書き前プレビュー、バックアップオプション)
-    - [x] 設定画面 (同期有効/無効、アカウント連携状態、手動同期)
-  - [x] エラーハンドリング・テスト
-    - [x] ネットワーク/認証エラー対応、リトライ機構
-    - [x] MockSyncAdapter実装、コンフリクトシナリオテスト
-  - [x] ストア統合・実装完了
-    - [x] ~~chordChartStoreへの同期機能統合~~ → **ストア分離対応済み** (PR#88)
-      - [x] chordChartStore分離 (396行→256行)
-      - [x] syncStore新規作成 (132行、19テスト)
-      - [x] 責務分離による保守性向上
-    - [x] **ストア間連携実装** (2024-12-16完了)
-      - [x] SyncResult型にmergedChartsフィールド追加
-      - [x] chordChartStoreにapplySyncedCharts()とイベント機能追加
-      - [x] SyncManagerでmergedCharts返却対応
-      - [x] useChartSyncカスタムフック作成（手動+自動同期）
-    - [x] **残り実装タスク** 
-      - [x] Header/MainLayoutへの同期UI追加  
-      - [x] App.tsxでの同期初期化処理
-      - [x] 初回認証フロー実装
-      - [x] Google Drive API認証エラーの修正（フォルダ作成処理）
 
 ### 最優先：E2Eテスト基盤構築
 - [ ] **E2Eテスト基盤構築** (推定工数: 1-2週間)
@@ -200,10 +170,6 @@
 - **最優先度**: E2Eテスト導入（PWA品質保証の観点から最重要）
 - **同期機能進捗**: ✅ 実装完了
 
-### 🎯 現在の状況（2025-06-17時点）
-- ✅ **PR#88**: chordChartStore分離完了（ストア責務分離）
-- ✅ **PR#89**: syncStore-chordChartStore連携実装完了
-- ✅ **PR#102**: Google Drive同期UI統合完了
-- ✅ **chordChartStoreリファクタリング**: 338行ストアを3ストアに分離（chartDataStore、chartCrudStore、useChartManagement統合フック）
-- ✅ **Google Drive同期機能実装完了**: 認証エラー修正（フォルダ自動作成処理）
-- 📋 **進捗**: 同期機能の全実装完了（基盤・ロジック・ストア連携・UI統合・エラーハンドリング）
+### 🎯 現在の状況（2025-06-18時点）
+- ✅ **Google Drive同期機能**: 全実装完了、TODO_DONE.mdに移動済み
+- 📋 **次の優先事項**: E2Eテスト基盤構築（品質保証・回帰防止）

--- a/TODO_DONE.md
+++ b/TODO_DONE.md
@@ -4,6 +4,39 @@
 
 ## 完了済み
 
+### 2025-06-18: Google Drive同期機能完全実装
+- [x] **複数環境でのスコア同期機能** (推定工数: 2-3週間)
+  - [x] 基盤層実装
+    - [x] Google API Console設定 (プロジェクト作成、OAuth 2.0設定) ※.env.exampleファイル作成済み
+    - [x] 認証フロー実装 (GoogleAuthProvider、トークン管理)
+    - [x] 同期アダプター層 (ISyncAdapter、GoogleDriveSyncAdapter)
+  - [x] 同期ロジック実装
+    - [x] タイムスタンプ管理 (lastSyncedAt、lastModifiedAt、deviceId)
+    - [x] コンフリクト検出 (後勝ち戦略、警告表示)
+    - [x] 同期実行フロー (pull → compare → warn → push)
+  - [x] UI/UX実装
+    - [x] 同期状態表示 (SyncStatusIndicator、最終同期時刻)
+    - [x] コンフリクト警告ダイアログ (上書き前プレビュー、バックアップオプション)
+    - [x] 設定画面 (同期有効/無効、アカウント連携状態、手動同期)
+  - [x] エラーハンドリング・テスト
+    - [x] ネットワーク/認証エラー対応、リトライ機構
+    - [x] MockSyncAdapter実装、コンフリクトシナリオテスト
+  - [x] ストア統合・実装完了
+    - [x] ~~chordChartStoreへの同期機能統合~~ → **ストア分離対応済み** (PR#88)
+      - [x] chordChartStore分離 (396行→256行)
+      - [x] syncStore新規作成 (132行、19テスト)
+      - [x] 責務分離による保守性向上
+    - [x] **ストア間連携実装** (2024-12-16完了)
+      - [x] SyncResult型にmergedChartsフィールド追加
+      - [x] chordChartStoreにapplySyncedCharts()とイベント機能追加
+      - [x] SyncManagerでmergedCharts返却対応
+      - [x] useChartSyncカスタムフック作成（手動+自動同期）
+    - [x] **残り実装タスク** 
+      - [x] Header/MainLayoutへの同期UI追加  
+      - [x] App.tsxでの同期初期化処理
+      - [x] 初回認証フロー実装
+      - [x] Google Drive API認証エラーの修正（フォルダ作成処理）
+
 ### 2025-01-15: コードメモ機能実装
 - [x] コードそれぞれに自由記述の「メモ」を割り当て可能
 - [x] 歌詞や演奏記号（クレッシェンド等）の記録


### PR DESCRIPTION
## Summary
- TODO.mdに完了タスク即時移行の運用ルールを追加
- Google Drive同期機能（完全実装済み）をTODO_DONE.mdへ移動
- 現在の状況を2025-06-18時点に更新

## Changes
1. **運用ルール追加**
   - 完了したタスクは即座にTODO_DONE.mdに移動する運用を明文化
   - タスクを完了したらすぐに該当行を削除してTODO_DONE.mdに追記

2. **完了タスクの移動**
   - Google Drive同期機能の全実装タスクをTODO_DONE.mdに移動
   - 2025-06-18付けで完了タスクとして記録

3. **現在の状況更新**
   - 同期機能完了を反映
   - 次の優先事項（E2Eテスト基盤構築）を明記

🤖 Generated with [Claude Code](https://claude.ai/code)