### PR TITLE
fix: フッターのコピーライト年を動的表示に変更

### DIFF
--- a/src/layouts/Footer.tsx
+++ b/src/layouts/Footer.tsx
@@ -10,7 +10,7 @@ const Footer: React.FC = () => {
       <footer className="bg-white border-t border-slate-200 px-4 py-3">
         <div className="flex flex-col sm:flex-row justify-between items-center gap-2 text-xs text-slate-500">
           <div>
-            © 2024 Nekogata Score Manager
+            © {new Date().getFullYear()} Nekogata Score Manager
           </div>
           <div className="flex gap-4">
             <button


### PR DESCRIPTION
## Summary
- フッターのコピーライト表記を固定値「2024」から動的な年表示に変更
- `new Date().getFullYear()` を使用して常に最新の年を表示

## Test plan
- [ ] フッターに現在の年（2025）が表示されることを確認
- [ ] ビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)