### PR TITLE
feat: PWAキャッシュ戦略をNetworkFirst方式に変更

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,49 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+        runtimeCaching: [
+          {
+            urlPattern: ({ request }) => request.destination === 'document',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'documents',
+              networkTimeoutSeconds: 3,
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 24 * 60 * 60 // 24 hours
+              }
+            }
+          },
+          {
+            urlPattern: ({ request }) => 
+              request.destination === 'script' || 
+              request.destination === 'style',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'assets',
+              networkTimeoutSeconds: 3,
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 24 * 60 * 60 // 24 hours
+              }
+            }
+          },
+          {
+            urlPattern: ({ request }) => request.destination === 'image',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'images',
+              networkTimeoutSeconds: 3,
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 30 * 24 * 60 * 60 // 30 days
+              }
+            }
+          }
+        ]
+      },
       manifest: {
         name: 'Nekogata Score Manager',
         short_name: 'NekogataScore',


### PR DESCRIPTION
## Summary
- PWAのキャッシュ戦略をアグレッシブなNetworkFirst方式に変更
- ネットワーク優先でキャッシュはオフライン時のフォールバック用に限定
- 3秒のタイムアウトでレスポンシブな体験を提供

## 変更内容
- **NetworkFirst戦略**: 常にネットワークを最優先し、タイムアウト時のみキャッシュを使用
- **リソース別最適化**: ドキュメント（24時間）、アセット（24時間）、画像（30日）の適切なキャッシュ期間
- **短いタイムアウト**: 3秒で迅速にキャッシュにフォールバック
- **自動期限切れ**: ストレージ使用量を制御

## Test plan
- [ ] `npm run build`でビルドが成功することを確認
- [ ] 開発サーバーでPWA機能が正常に動作することを確認
- [ ] ネットワーク切断時にキャッシュからロードされることを確認
- [ ] ブラウザの開発者ツールでService Workerの動作を確認

🤖 Generated with [Claude Code](https://claude.ai/code)