### PR TITLE
同期エラー表示を統合してモバイルUX改善

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,3 +260,9 @@ Nekogata Score Managerでは、統一感があり直感的なユーザーイン�
 - パディング: `px-3 py-2` (ボタン), `p-4` (カード)
 
 この色彩設計により、ユーザーは直感的に各要素の機能を理解でき、一貫性のある操作体験を得ることができます。
+
+## Project Testing Information
+
+### E2E Testing
+
+- **E2E Tests Location**: e2eディレクトリにE2Eテストがある

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "claude-code-playground",
+  "name": "nekogata-score-manager",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "claude-code-playground",
+      "name": "nekogata-score-manager",
       "version": "0.0.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/src/components/sync/SyncDropdown.tsx
+++ b/src/components/sync/SyncDropdown.tsx
@@ -1,0 +1,117 @@
+import React, { useRef, useEffect, useState } from 'react';
+import { useChartSync } from '../../hooks/useChartSync';
+
+interface SyncDropdownProps {
+  showDropdown: boolean;
+  setShowDropdown: (show: boolean) => void;
+  onOpenSettings: () => void;
+}
+
+const SyncDropdown: React.FC<SyncDropdownProps> = ({
+  showDropdown,
+  setShowDropdown,
+  onOpenSettings,
+}) => {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [syncInProgress, setSyncInProgress] = useState(false);
+  const { isAuthenticated, syncCharts, isSyncing } = useChartSync();
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!dropdownRef.current?.contains(event.target as Node)) {
+        setShowDropdown(false);
+      }
+    };
+
+    if (showDropdown) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }
+  }, [showDropdown, setShowDropdown]);
+
+  const handleSyncClick = async () => {
+    if (!isAuthenticated || syncInProgress || isSyncing) return;
+
+    setSyncInProgress(true);
+    setShowDropdown(false);
+
+    try {
+      await syncCharts();
+      // 成功時の通知は将来的にトースト等で実装
+    } catch (error) {
+      console.error('Sync failed:', error);
+      // エラー時の処理は既存のSyncErrorで表示される
+    } finally {
+      setSyncInProgress(false);
+    }
+  };
+
+  const handleSettingsClick = () => {
+    setShowDropdown(false);
+    onOpenSettings();
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setShowDropdown(!showDropdown)}
+        className="px-3 py-2 rounded-md bg-slate-100 border border-slate-300 text-slate-600 hover:bg-slate-200 hover:text-slate-700 hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm transition-all duration-150 text-sm font-medium"
+        title="同期オプション"
+        data-testid="sync-dropdown-button"
+      >
+        <span className="flex items-center gap-2">
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          <span className="hidden sm:inline">同期</span>
+          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </span>
+      </button>
+      
+      {showDropdown && (
+        <div className="absolute top-full right-0 mt-1 bg-white border border-slate-200 rounded-md shadow-lg z-10 min-w-48">
+          <button
+            onClick={handleSyncClick}
+            disabled={!isAuthenticated || syncInProgress || isSyncing}
+            className={`block w-full text-left px-3 py-2 text-sm transition-colors ${
+              isAuthenticated && !syncInProgress && !isSyncing
+                ? 'text-slate-700 hover:bg-slate-100'
+                : 'text-slate-400 cursor-not-allowed'
+            }`}
+            data-testid="sync-execute-button"
+          >
+            <div className="flex items-center gap-2">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+              {syncInProgress || isSyncing ? '同期中...' : '今すぐ同期'}
+            </div>
+          </button>
+          
+          <div className="border-t border-slate-200"></div>
+          
+          <button
+            onClick={handleSettingsClick}
+            className="block w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-slate-100"
+            data-testid="sync-settings-button"
+          >
+            <div className="flex items-center gap-2">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              {isAuthenticated ? '詳細設定' : 'アカウント連携'}
+            </div>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export { SyncDropdown };

--- a/src/components/sync/SyncSettingsDialog.tsx
+++ b/src/components/sync/SyncSettingsDialog.tsx
@@ -170,21 +170,6 @@ export const SyncSettingsDialog: React.FC<SyncSettingsDialogProps> = ({
             </button>
           </div>
 
-          {/* 同期間隔 */}
-          <div className="space-y-2">
-            <label className="text-sm text-slate-700">同期間隔</label>
-            <select
-              value={config.syncInterval}
-              onChange={(e) => handleConfigChange({ syncInterval: Number(e.target.value) })}
-              className="w-full text-sm p-2 border border-slate-200 rounded"
-              disabled={!isAuthenticated || !config.autoSync}
-            >
-              <option value={5}>5分</option>
-              <option value={15}>15分</option>
-              <option value={30}>30分</option>
-              <option value={60}>1時間</option>
-            </select>
-          </div>
 
           {/* コンフリクト解決方法 */}
           <div className="space-y-2">

--- a/src/components/sync/SyncStatusIndicator.tsx
+++ b/src/components/sync/SyncStatusIndicator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { CloudArrowUpIcon, CloudIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { useSyncStore } from '../../stores/syncStore';
 import { logger } from '../../utils/logger';
@@ -9,12 +9,30 @@ interface SyncStatusIndicatorProps {
 
 export const SyncStatusIndicator: React.FC<SyncStatusIndicatorProps> = ({ className = '' }) => {
   const { isSyncing, lastSyncTime, syncError, isAuthenticated } = useSyncStore();
+  const [showErrorDetail, setShowErrorDetail] = useState(false);
+  const errorDetailRef = useRef<HTMLDivElement>(null);
   
   // デバッグログを追加
   logger.debug('SyncStatusIndicator Authentication status:', isAuthenticated);
   logger.debug('SyncStatusIndicator isSyncing:', isSyncing);
   logger.debug('SyncStatusIndicator lastSyncTime:', lastSyncTime);
   logger.debug('SyncStatusIndicator syncError:', syncError);
+  
+  // エラー詳細を外クリックで閉じる
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (errorDetailRef.current && !errorDetailRef.current.contains(event.target as Node)) {
+        setShowErrorDetail(false);
+      }
+    };
+
+    if (showErrorDetail) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }
+  }, [showErrorDetail]);
   
   if (!isAuthenticated) {
     return null;
@@ -38,7 +56,7 @@ export const SyncStatusIndicator: React.FC<SyncStatusIndicatorProps> = ({ classN
   };
   
   return (
-    <div className={`flex items-center gap-2 text-xs text-slate-600 ${className}`}>
+    <div className={`relative flex items-center gap-2 text-xs text-slate-600 ${className}`}>
       {syncStatus === 'syncing' ? (
         <>
           <CloudArrowUpIcon className="w-4 h-4 animate-pulse" />
@@ -46,13 +64,30 @@ export const SyncStatusIndicator: React.FC<SyncStatusIndicatorProps> = ({ classN
         </>
       ) : syncStatus === 'error' ? (
         <>
-          <ExclamationTriangleIcon className="w-4 h-4 text-[#EE5840]" />
-          <span className="text-[#EE5840]">同期エラー</span>
+          <button
+            className="flex items-center gap-1 text-[#EE5840] hover:text-red-700 focus:outline-none"
+            onClick={() => setShowErrorDetail(!showErrorDetail)}
+            title="エラー詳細を表示"
+          >
+            <ExclamationTriangleIcon className="w-4 h-4" />
+            <span>同期エラー</span>
+          </button>
+          {showErrorDetail && (
+            <div 
+              ref={errorDetailRef}
+              className="absolute top-full right-0 mt-1 p-2 bg-white border border-slate-200 rounded-md shadow-lg z-10 max-w-xs"
+            >
+              <p className="text-xs text-[#EE5840] whitespace-pre-wrap break-words">
+                {syncError}
+              </p>
+            </div>
+          )}
         </>
       ) : (
         <>
           <CloudIcon className="w-4 h-4" />
-          <span>最終同期: {formatLastSync(lastSyncTime)}</span>
+          <span className="hidden sm:inline">最終同期: {formatLastSync(lastSyncTime)}</span>
+          <span className="sm:hidden">{formatLastSync(lastSyncTime)}</span>
         </>
       )}
     </div>

--- a/src/components/sync/__tests__/SyncDropdown.test.tsx
+++ b/src/components/sync/__tests__/SyncDropdown.test.tsx
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SyncDropdown } from '../SyncDropdown';
+
+vi.mock('../../../hooks/useChartSync');
+
+const mockUseChartSync = {
+  // 同期関連
+  syncCharts: vi.fn(),
+  isSyncing: false,
+  lastSyncTime: null as Date | null,
+  syncError: null as string | null,
+  syncConfig: {
+    autoSync: false,
+    conflictResolution: 'remote' as const,
+    showConflictWarning: true,
+  },
+  
+  // 認証関連
+  isAuthenticated: false,
+  authenticate: vi.fn(),
+  signOut: vi.fn(),
+  
+  // 設定関連
+  updateSyncConfig: vi.fn(),
+  clearSyncError: vi.fn(),
+  
+  // チャート関連
+  charts: {},
+  currentChartId: null as string | null,
+  isLoading: false,
+  error: null as string | null,
+};
+
+describe('SyncDropdown', () => {
+  const mockSetShowDropdown = vi.fn();
+  const mockOnOpenSettings = vi.fn();
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    
+    const { useChartSync } = await import('../../../hooks/useChartSync');
+    vi.mocked(useChartSync).mockReturnValue(mockUseChartSync);
+    
+    // Reset mock state
+    mockUseChartSync.isAuthenticated = false;
+    mockUseChartSync.isSyncing = false;
+    mockUseChartSync.syncCharts.mockResolvedValue({ success: true });
+  });
+
+  it('should render sync dropdown button', () => {
+    render(
+      <SyncDropdown
+        showDropdown={false}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    expect(screen.getByTestId('sync-dropdown-button')).toBeInTheDocument();
+    expect(screen.getByText('同期')).toBeInTheDocument();
+  });
+
+  it('should show dropdown when showDropdown is true', () => {
+    render(
+      <SyncDropdown
+        showDropdown={true}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    expect(screen.getByTestId('sync-execute-button')).toBeInTheDocument();
+    expect(screen.getByTestId('sync-settings-button')).toBeInTheDocument();
+  });
+
+  it('should not show dropdown when showDropdown is false', () => {
+    render(
+      <SyncDropdown
+        showDropdown={false}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    expect(screen.queryByTestId('sync-execute-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sync-settings-button')).not.toBeInTheDocument();
+  });
+
+  it('should toggle dropdown when button is clicked', () => {
+    render(
+      <SyncDropdown
+        showDropdown={false}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('sync-dropdown-button'));
+    expect(mockSetShowDropdown).toHaveBeenCalledWith(true);
+  });
+
+  it('should disable sync button when not authenticated', () => {
+    mockUseChartSync.isAuthenticated = false;
+
+    render(
+      <SyncDropdown
+        showDropdown={true}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    const syncButton = screen.getByTestId('sync-execute-button');
+    expect(syncButton).toBeDisabled();
+    expect(syncButton).toHaveClass('text-slate-400', 'cursor-not-allowed');
+  });
+
+  it('should enable sync button when authenticated', () => {
+    mockUseChartSync.isAuthenticated = true;
+
+    render(
+      <SyncDropdown
+        showDropdown={true}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    const syncButton = screen.getByTestId('sync-execute-button');
+    expect(syncButton).not.toBeDisabled();
+    expect(syncButton).toHaveClass('text-slate-700');
+  });
+
+  it('should execute sync when sync button is clicked and authenticated', async () => {
+    mockUseChartSync.isAuthenticated = true;
+
+    render(
+      <SyncDropdown
+        showDropdown={true}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('sync-execute-button'));
+
+    await waitFor(() => {
+      expect(mockUseChartSync.syncCharts).toHaveBeenCalled();
+    });
+    expect(mockSetShowDropdown).toHaveBeenCalledWith(false);
+  });
+
+  it('should not execute sync when not authenticated', () => {
+    mockUseChartSync.isAuthenticated = false;
+
+    render(
+      <SyncDropdown
+        showDropdown={true}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('sync-execute-button'));
+
+    expect(mockUseChartSync.syncCharts).not.toHaveBeenCalled();
+  });
+
+  it('should show "同期中..." when sync is in progress', () => {
+    mockUseChartSync.isSyncing = true;
+
+    render(
+      <SyncDropdown
+        showDropdown={true}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    expect(screen.getByText('同期中...')).toBeInTheDocument();
+    expect(screen.getByTestId('sync-execute-button')).toBeDisabled();
+  });
+
+  it('should open settings when settings button is clicked', () => {
+    render(
+      <SyncDropdown
+        showDropdown={true}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('sync-settings-button'));
+
+    expect(mockOnOpenSettings).toHaveBeenCalled();
+    expect(mockSetShowDropdown).toHaveBeenCalledWith(false);
+  });
+
+  it('should show "アカウント連携" when not authenticated', () => {
+    mockUseChartSync.isAuthenticated = false;
+
+    render(
+      <SyncDropdown
+        showDropdown={true}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    expect(screen.getByText('アカウント連携')).toBeInTheDocument();
+  });
+
+  it('should show "詳細設定" when authenticated', () => {
+    mockUseChartSync.isAuthenticated = true;
+
+    render(
+      <SyncDropdown
+        showDropdown={true}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    expect(screen.getByText('詳細設定')).toBeInTheDocument();
+  });
+
+  it('should handle sync errors gracefully', async () => {
+    mockUseChartSync.isAuthenticated = true;
+    mockUseChartSync.syncCharts.mockRejectedValue(new Error('Sync failed'));
+    
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <SyncDropdown
+        showDropdown={true}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('sync-execute-button'));
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith('Sync failed:', expect.any(Error));
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should close dropdown when clicking outside', () => {
+    render(
+      <SyncDropdown
+        showDropdown={true}
+        setShowDropdown={mockSetShowDropdown}
+        onOpenSettings={mockOnOpenSettings}
+      />
+    );
+
+    // Simulate clicking outside
+    fireEvent.mouseDown(document.body);
+
+    expect(mockSetShowDropdown).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/sync/__tests__/SyncSettingsDialog.test.tsx
+++ b/src/components/sync/__tests__/SyncSettingsDialog.test.tsx
@@ -22,7 +22,6 @@ const mockUseChartSync = {
   syncError: null as string | null,
   syncConfig: {
     autoSync: false,
-    syncInterval: 5,
     conflictResolution: 'remote' as const,
     showConflictWarning: true,
   },
@@ -52,7 +51,6 @@ describe('SyncSettingsDialog', () => {
     
     mockSyncManager.getConfig.mockReturnValue({
       autoSync: false,
-      syncInterval: 5,
       conflictResolution: 'remote',
       showConflictWarning: true,
     });
@@ -157,22 +155,6 @@ describe('SyncSettingsDialog', () => {
     expect(mockUseChartSync.updateSyncConfig).toHaveBeenCalled();
   });
 
-  it('同期間隔の設定を変更できる', async () => {
-    mockUseChartSync.isAuthenticated = true;
-    
-    render(<SyncSettingsDialog isOpen={true} onClose={() => {}} />);
-    
-    await waitFor(() => {
-      const intervalSelect = screen.getByDisplayValue('5分');
-      fireEvent.change(intervalSelect, { target: { value: '15' } });
-    });
-    
-    expect(mockUseChartSync.updateSyncConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        syncInterval: 15
-      })
-    );
-  });
 
   it('コンフリクト解決の設定を変更できる', async () => {
     mockUseChartSync.isAuthenticated = true;
@@ -195,10 +177,8 @@ describe('SyncSettingsDialog', () => {
     render(<SyncSettingsDialog isOpen={true} onClose={() => {}} />);
     
     await waitFor(() => {
-      const intervalSelect = screen.getByDisplayValue('5分');
       const conflictSelect = screen.getByDisplayValue('リモート優先');
       
-      expect(intervalSelect).toBeDisabled();
       expect(conflictSelect).toBeDisabled();
     });
   });

--- a/src/components/sync/__tests__/SyncStatusIndicator.test.tsx
+++ b/src/components/sync/__tests__/SyncStatusIndicator.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SyncStatusIndicator } from '../SyncStatusIndicator';
+
+vi.mock('../../../stores/syncStore');
+
+const mockUseSyncStore = {
+  isSyncing: false,
+  lastSyncTime: null as Date | null,
+  syncError: null as string | null,
+  isAuthenticated: false,
+};
+
+describe('SyncStatusIndicator', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    
+    const { useSyncStore } = await import('../../../stores/syncStore');
+    vi.mocked(useSyncStore).mockReturnValue(mockUseSyncStore);
+    
+    // Reset mock state
+    mockUseSyncStore.isAuthenticated = false;
+    mockUseSyncStore.isSyncing = false;
+    mockUseSyncStore.lastSyncTime = null;
+    mockUseSyncStore.syncError = null;
+  });
+
+  it('should not render when not authenticated', () => {
+    mockUseSyncStore.isAuthenticated = false;
+
+    const { container } = render(<SyncStatusIndicator />);
+    
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should show syncing status when syncing', () => {
+    mockUseSyncStore.isAuthenticated = true;
+    mockUseSyncStore.isSyncing = true;
+
+    render(<SyncStatusIndicator />);
+    
+    expect(screen.getByText('同期中...')).toBeInTheDocument();
+  });
+
+  it('should show error status when there is an error', () => {
+    mockUseSyncStore.isAuthenticated = true;
+    mockUseSyncStore.syncError = 'Sync failed';
+
+    render(<SyncStatusIndicator />);
+    
+    expect(screen.getByText('同期エラー')).toBeInTheDocument();
+  });
+
+  it('should show error detail when error button is clicked', () => {
+    mockUseSyncStore.isAuthenticated = true;
+    mockUseSyncStore.syncError = 'Network error occurred';
+
+    render(<SyncStatusIndicator />);
+    
+    const errorButton = screen.getByText('同期エラー');
+    fireEvent.click(errorButton);
+    
+    expect(screen.getByText('Network error occurred')).toBeInTheDocument();
+  });
+
+  it('should hide error detail when clicking outside', () => {
+    mockUseSyncStore.isAuthenticated = true;
+    mockUseSyncStore.syncError = 'Network error occurred';
+
+    render(<SyncStatusIndicator />);
+    
+    // Show error detail
+    const errorButton = screen.getByText('同期エラー');
+    fireEvent.click(errorButton);
+    expect(screen.getByText('Network error occurred')).toBeInTheDocument();
+    
+    // Click outside to hide
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText('Network error occurred')).not.toBeInTheDocument();
+  });
+
+  it('should show last sync time when idle', () => {
+    mockUseSyncStore.isAuthenticated = true;
+    mockUseSyncStore.lastSyncTime = new Date('2024-01-01T12:00:00Z');
+
+    render(<SyncStatusIndicator />);
+    
+    // Should show some sync time text (multiple elements due to responsive display)
+    expect(screen.getAllByText(/日前|時間前|分前|たった今|未同期/).length).toBeGreaterThan(0);
+  });
+
+  it('should show "未同期" when lastSyncTime is null', () => {
+    mockUseSyncStore.isAuthenticated = true;
+    mockUseSyncStore.lastSyncTime = null;
+
+    render(<SyncStatusIndicator />);
+    
+    expect(screen.getByText('未同期')).toBeInTheDocument();
+  });
+
+  it('should apply custom className', () => {
+    mockUseSyncStore.isAuthenticated = true;
+    
+    const { container } = render(<SyncStatusIndicator className="custom-class" />);
+    
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+});

--- a/src/hooks/__tests__/useChartSync.test.ts
+++ b/src/hooks/__tests__/useChartSync.test.ts
@@ -30,7 +30,6 @@ interface MockSyncStore {
   syncError: string | null;
   syncConfig: {
     autoSync: boolean;
-    syncInterval: number;
     conflictResolution: string;
     showConflictWarning: boolean;
   };
@@ -76,7 +75,6 @@ const mockSyncStore: MockSyncStore = {
   syncError: null,
   syncConfig: {
     autoSync: false,
-    syncInterval: 5,
     conflictResolution: 'remote',
     showConflictWarning: true
   },
@@ -121,7 +119,6 @@ describe('useChartSync', () => {
       syncError: null,
       syncConfig: {
         autoSync: false,
-        syncInterval: 5,
         conflictResolution: 'remote',
         showConflictWarning: true
       },
@@ -406,84 +403,6 @@ describe('useChartSync', () => {
     });
   });
 
-  describe('periodic sync timer', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    it('should set up periodic sync when auto sync is enabled and authenticated', () => {
-      const chart1 = createNewChordChart({ title: 'Chart 1' });
-      mockChordChartStore.charts = { [chart1.id]: chart1 };
-      mockSyncStore.syncConfig.autoSync = true;
-      mockSyncStore.syncConfig.syncInterval = 5; // 5 minutes
-      mockSyncStore.isAuthenticated = true;
-      mockSyncStore.isSyncing = false;
-
-      const { unmount } = renderHook(() => useChartSync());
-
-      // Verify that setInterval was called
-      expect(vi.getTimerCount()).toBeGreaterThan(0);
-
-      // Cleanup
-      unmount();
-    });
-
-    it('should not set up timer when auto sync is disabled', () => {
-      mockSyncStore.syncConfig.autoSync = false;
-      mockSyncStore.isAuthenticated = true;
-
-      renderHook(() => useChartSync());
-
-      act(() => {
-        vi.advanceTimersByTime(10 * 60 * 1000); // 10 minutes
-      });
-
-      expect(mockSyncStore.sync).not.toHaveBeenCalled();
-    });
-
-    it('should not sync during timer if already syncing', async () => {
-      mockSyncStore.syncConfig.autoSync = true;
-      mockSyncStore.isAuthenticated = true;
-      mockSyncStore.isSyncing = true; // Already syncing
-
-      renderHook(() => useChartSync());
-
-      await act(async () => {
-        vi.advanceTimersByTime(5 * 60 * 1000);
-      });
-
-      expect(mockSyncStore.sync).not.toHaveBeenCalled();
-    });
-
-    it('should handle periodic sync errors silently', () => {
-      mockSyncStore.syncConfig.autoSync = true;
-      mockSyncStore.isAuthenticated = true;
-      mockSyncStore.isSyncing = false;
-
-      const { unmount } = renderHook(() => useChartSync());
-
-      // Just verify timer is set up
-      expect(vi.getTimerCount()).toBeGreaterThan(0);
-
-      // Cleanup
-      unmount();
-    });
-
-    it('should clear timer on unmount', () => {
-      mockSyncStore.syncConfig.autoSync = true;
-      mockSyncStore.isAuthenticated = true;
-
-      const { unmount } = renderHook(() => useChartSync());
-
-      // Verify timer was created
-      expect(vi.getTimerCount()).toBeGreaterThan(0);
-
-      unmount();
-
-      // Verify timer was cleared
-      expect(vi.getTimerCount()).toBe(0);
-    });
-  });
 
   describe('combined loading state', () => {
     it('should combine chart store and sync store loading states', () => {

--- a/src/hooks/useChartSync.ts
+++ b/src/hooks/useChartSync.ts
@@ -106,44 +106,6 @@ export const useChartSync = () => {
     syncStore
   ]);
 
-  // 定期同期タイマー
-  useEffect(() => {
-    const isAutoSyncEnabled = syncStore.syncConfig.autoSync;
-    const isAuthenticated = syncStore.isAuthenticated;
-    
-    if (!isAutoSyncEnabled || !isAuthenticated) {
-      return;
-    }
-
-    const intervalMs = syncStore.syncConfig.syncInterval * 60 * 1000;
-    const interval = setInterval(async () => {
-      try {
-        if (!syncStore.isSyncing) {
-          const charts = Object.values(chordChartStore.charts);
-          console.log(`[SYNC] Periodic sync triggered with ${charts.length} charts`);
-          const result = await syncStore.sync(charts);
-          
-          if (result.success && result.mergedCharts) {
-            console.log(`[SYNC] Periodic sync applying ${result.mergedCharts.length} charts`);
-            await chordChartStore.applySyncedCharts(result.mergedCharts);
-            console.log(`[SYNC] Periodic sync applySyncedCharts completed`);
-          } else {
-            console.log(`[SYNC] Periodic sync - not applying charts:`, { success: result.success, mergedCharts: result.mergedCharts });
-          }
-        }
-      } catch (error) {
-        console.error('定期同期エラー:', error);
-      }
-    }, intervalMs);
-
-    return () => clearInterval(interval);
-  }, [
-    syncStore.syncConfig.autoSync,
-    syncStore.syncConfig.syncInterval,
-    syncStore.isSyncing,
-    chordChartStore,
-    syncStore
-  ]);
 
   return {
     // 同期関連

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -3,7 +3,7 @@ import { useWakeLock } from '../hooks/useWakeLock';
 import { useHiddenFeatures } from '../hooks/useHiddenFeatures';
 import { SyncSettingsDialog } from '../components/sync/SyncSettingsDialog';
 import { SyncStatusIndicator } from '../components/sync/SyncStatusIndicator';
-import { useChartSync } from '../hooks/useChartSync';
+import { SyncDropdown } from '../components/sync/SyncDropdown';
 
 interface HeaderProps {
   explorerOpen: boolean;
@@ -14,7 +14,7 @@ const Header: React.FC<HeaderProps> = ({ explorerOpen, setExplorerOpen }) => {
   const { isActive: wakeLockActive, isSupported: wakeLockSupported, toggleWakeLock } = useWakeLock();
   const { syncSettings } = useHiddenFeatures();
   const [syncSettingsOpen, setSyncSettingsOpen] = useState(false);
-  const { syncError } = useChartSync();
+  const [syncDropdownOpen, setSyncDropdownOpen] = useState(false);
 
   return (
     <header className="bg-white shadow-sm border-b border-slate-200" data-testid="header">
@@ -41,29 +41,16 @@ const Header: React.FC<HeaderProps> = ({ explorerOpen, setExplorerOpen }) => {
           <h1 className="text-xl font-semibold text-slate-900" data-testid="app-title">Nekogata Score Manager</h1>
           <div className="flex-1"></div>
           {syncSettings && (
-            <>
-              <SyncStatusIndicator className="mr-4" />
-              {syncError && (
-                <div className="text-xs text-[#EE5840] mr-4">
-                  同期エラー: {syncError}
-                </div>
-              )}
-            </>
+            <SyncStatusIndicator className="mr-4" />
           )}
           {syncSettings && (
-            <button
-              onClick={() => setSyncSettingsOpen(true)}
-              className="px-3 py-2 rounded-md bg-slate-100 border border-slate-300 text-slate-600 hover:bg-slate-200 hover:text-slate-700 hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 mr-3 shadow-sm transition-all duration-150 text-sm font-medium"
-              title="Google Drive同期設定"
-              data-testid="sync-settings-button"
-            >
-              <span className="flex items-center gap-2">
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                </svg>
-                <span className="hidden sm:inline">同期設定</span>
-              </span>
-            </button>
+            <div className="mr-3">
+              <SyncDropdown
+                showDropdown={syncDropdownOpen}
+                setShowDropdown={setSyncDropdownOpen}
+                onOpenSettings={() => setSyncSettingsOpen(true)}
+              />
+            </div>
           )}
           {wakeLockSupported && (
             <button

--- a/src/stores/__tests__/syncStore.test.ts
+++ b/src/stores/__tests__/syncStore.test.ts
@@ -63,7 +63,6 @@ describe('syncStore', () => {
       syncError: null,
       syncConfig: {
         autoSync: false,
-        syncInterval: 5,
         conflictResolution: 'remote',
         showConflictWarning: true
       }
@@ -84,7 +83,6 @@ describe('syncStore', () => {
       expect(state.syncError).toBeNull();
       expect(state.syncConfig).toEqual({
         autoSync: false,
-        syncInterval: 5,
         conflictResolution: 'remote',
         showConflictWarning: true
       });
@@ -95,7 +93,6 @@ describe('syncStore', () => {
     it('正常に初期化される', async () => {
       const mockConfig = {
         autoSync: true,
-        syncInterval: 10,
         conflictResolution: 'local' as const,
         showConflictWarning: false
       };
@@ -132,7 +129,6 @@ describe('syncStore', () => {
     it('最終同期時刻が0の場合はnullが設定される', async () => {
       const mockConfig = {
         autoSync: false,
-        syncInterval: 5,
         conflictResolution: 'remote' as const,
         showConflictWarning: true
       };
@@ -154,7 +150,6 @@ describe('syncStore', () => {
       mockSyncManager.initialize.mockResolvedValue(undefined);
       mockSyncManager.getConfig.mockReturnValue({
         autoSync: false,
-        syncInterval: 5,
         conflictResolution: 'remote',
         showConflictWarning: true
       });
@@ -197,7 +192,6 @@ describe('syncStore', () => {
       mockSyncManager.initialize.mockResolvedValue(undefined);
       mockSyncManager.getConfig.mockReturnValue({
         autoSync: false,
-        syncInterval: 5,
         conflictResolution: 'remote',
         showConflictWarning: true
       });
@@ -268,7 +262,6 @@ describe('syncStore', () => {
       mockSyncManager.initialize.mockResolvedValue(undefined);
       mockSyncManager.getConfig.mockReturnValue({
         autoSync: false,
-        syncInterval: 5,
         conflictResolution: 'remote',
         showConflictWarning: true
       });
@@ -354,7 +347,6 @@ describe('syncStore', () => {
       mockSyncManager.initialize.mockResolvedValue(undefined);
       mockSyncManager.getConfig.mockReturnValue({
         autoSync: false,
-        syncInterval: 5,
         conflictResolution: 'remote',
         showConflictWarning: true
       });
@@ -364,20 +356,18 @@ describe('syncStore', () => {
     });
 
     it('設定が正常に更新される', () => {
-      const configUpdate = { autoSync: true, syncInterval: 10 };
+      const configUpdate = { autoSync: true };
 
       useSyncStore.getState().updateSyncConfig(configUpdate);
 
       expect(mockSyncManager.saveConfig).toHaveBeenCalledWith({
         autoSync: true,
-        syncInterval: 10,
         conflictResolution: 'remote',
         showConflictWarning: true
       });
 
       const state = useSyncStore.getState();
       expect(state.syncConfig.autoSync).toBe(true);
-      expect(state.syncConfig.syncInterval).toBe(10);
     });
 
     it('syncManagerがnullの場合でも設定は更新される', () => {
@@ -398,7 +388,6 @@ describe('syncStore', () => {
       mockSyncManager.initialize.mockResolvedValue(undefined);
       mockSyncManager.getConfig.mockReturnValue({
         autoSync: false,
-        syncInterval: 5,
         conflictResolution: 'remote',
         showConflictWarning: true
       });

--- a/src/stores/syncStore.ts
+++ b/src/stores/syncStore.ts
@@ -34,7 +34,6 @@ export const useSyncStore = create<SyncState>()(
       syncError: null,
       syncConfig: {
         autoSync: false,
-        syncInterval: 5,
         conflictResolution: 'remote',
         showConflictWarning: true
       },

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -54,7 +54,6 @@ export interface ISyncAdapter {
 
 export interface SyncConfig {
   autoSync: boolean;
-  syncInterval: number; // minutes
   conflictResolution: 'local' | 'remote' | 'manual';
   showConflictWarning: boolean;
 }

--- a/src/utils/sync/__tests__/syncManager.test.ts
+++ b/src/utils/sync/__tests__/syncManager.test.ts
@@ -182,7 +182,6 @@ describe('SyncManager', () => {
       
       expect(config).toEqual({
         autoSync: false,
-        syncInterval: 5,
         conflictResolution: 'remote',
         showConflictWarning: true
       });
@@ -191,7 +190,6 @@ describe('SyncManager', () => {
     it('should save and load config', () => {
       const newConfig = {
         autoSync: true,
-        syncInterval: 10,
         conflictResolution: 'local' as const,
         showConflictWarning: false
       };

--- a/src/utils/sync/syncManager.ts
+++ b/src/utils/sync/syncManager.ts
@@ -283,12 +283,17 @@ export class SyncManager {
   private loadConfig(): SyncConfig {
     const stored = localStorage.getItem('nekogata-sync-config');
     if (stored) {
-      return JSON.parse(stored);
+      const parsed = JSON.parse(stored);
+      // 古い設定との互換性のために、不要なプロパティを除外
+      return {
+        autoSync: parsed.autoSync ?? false,
+        conflictResolution: parsed.conflictResolution ?? 'remote',
+        showConflictWarning: parsed.showConflictWarning ?? true
+      };
     }
     
     return {
       autoSync: false,
-      syncInterval: 5,
       conflictResolution: 'remote',
       showConflictWarning: true
     };


### PR DESCRIPTION
## Summary
- 定期同期機能を削除してパフォーマンス時の意図しない同期を防止
- 同期ボタンをドロップダウン化してワンクリック同期を実現
- 同期エラー表示をSyncStatusIndicatorに統合してモバイルヘッダーのスペース効率を向上

## Test plan
- [ ] 同期ドロップダウンの動作確認（今すぐ同期、詳細設定）
- [ ] 同期エラー時のインジケータクリックでエラー詳細表示
- [ ] モバイル表示でのヘッダーレイアウト確認
- [ ] 全テストの実行確認

🤖 Generated with [Claude Code](https://claude.ai/code)