### PR TITLE
feat: アクセストークンの自動リフレッシュ機能実装

### DIFF
--- a/public/auth/callback.html
+++ b/public/auth/callback.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>認証中... - Nekogata Score Manager</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background-color: #f8fafc;
+        }
+        .container {
+            text-align: center;
+            padding: 2rem;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+        }
+        .spinner {
+            width: 40px;
+            height: 40px;
+            border: 4px solid #e2e8f0;
+            border-top: 4px solid #85B0B7;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            margin: 0 auto 1rem;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        .error {
+            color: #ef4444;
+            margin-top: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="spinner"></div>
+        <h2>認証処理中...</h2>
+        <p>しばらくお待ちください。</p>
+        <div id="error-message" class="error" style="display: none;"></div>
+    </div>
+
+    <script>
+        (async function() {
+            try {
+                const urlParams = new URLSearchParams(window.location.search);
+                const code = urlParams.get('code');
+                const state = urlParams.get('state');
+                const error = urlParams.get('error');
+
+                if (error) {
+                    throw new Error(`認証エラー: ${error}`);
+                }
+
+                if (!code || !state) {
+                    throw new Error('必要なパラメータが不足しています');
+                }
+
+                // 親ウィンドウに成功を通知
+                if (window.opener) {
+                    window.opener.postMessage({
+                        type: 'OAUTH_SUCCESS',
+                        code: code,
+                        state: state
+                    }, window.location.origin);
+                    window.close();
+                } else {
+                    // 直接アクセスされた場合はメインページにリダイレクト
+                    window.location.href = '/';
+                }
+            } catch (error) {
+                console.error('Authentication callback error:', error);
+                
+                const errorElement = document.getElementById('error-message');
+                errorElement.textContent = error.message;
+                errorElement.style.display = 'block';
+                
+                // 親ウィンドウにエラーを通知
+                if (window.opener) {
+                    window.opener.postMessage({
+                        type: 'OAUTH_ERROR',
+                        error: error.message
+                    }, window.location.origin);
+                    
+                    // 5秒後にウィンドウを閉じる
+                    setTimeout(() => {
+                        window.close();
+                    }, 5000);
+                }
+            }
+        })();
+    </script>
+</body>
+</html>

--- a/src/utils/sync/__tests__/googleAuth.test.ts
+++ b/src/utils/sync/__tests__/googleAuth.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { GoogleAuthProvider } from '../googleAuth';
+
+// モック設定
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// crypto.getRandomValues のモック
+Object.defineProperty(global, 'crypto', {
+  value: {
+    getRandomValues: vi.fn((arr: Uint8Array) => {
+      for (let i = 0; i < arr.length; i++) {
+        arr[i] = Math.floor(Math.random() * 256);
+      }
+      return arr;
+    }),
+    subtle: {
+      digest: vi.fn().mockResolvedValue(new ArrayBuffer(32)),
+    },
+  },
+});
+
+// btoa のモック
+global.btoa = vi.fn((str: string) => Buffer.from(str, 'binary').toString('base64'));
+
+// sessionStorage と localStorage のモック
+const sessionStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+};
+
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+};
+
+Object.defineProperty(global, 'sessionStorage', { value: sessionStorageMock });
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+// window.open のモック
+const mockWindow = {
+  closed: false,
+  close: vi.fn(),
+};
+global.window.open = vi.fn().mockReturnValue(mockWindow);
+
+
+describe('GoogleAuthProvider', () => {
+  let authProvider: GoogleAuthProvider;
+
+  beforeEach(() => {
+    // シングルトンのリセット
+    GoogleAuthProvider.resetInstance();
+    authProvider = GoogleAuthProvider.getInstance('test-client-id');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    sessionStorageMock.getItem.mockClear();
+    sessionStorageMock.setItem.mockClear();
+    sessionStorageMock.removeItem.mockClear();
+    localStorageMock.getItem.mockClear();
+    localStorageMock.setItem.mockClear();
+    localStorageMock.removeItem.mockClear();
+  });
+
+  describe('initialize', () => {
+    it('CLIENT_IDが設定されていない場合エラーを投げる', async () => {
+      GoogleAuthProvider.resetInstance();
+      const provider = GoogleAuthProvider.getInstance(''); // 空のクライアントID
+      
+      await expect(provider.initialize()).rejects.toThrow('Google Client ID not configured');
+    });
+
+    it('正常に初期化される', async () => {
+      GoogleAuthProvider.resetInstance();
+      const provider = GoogleAuthProvider.getInstance('test-client-id');
+      
+      await expect(provider.initialize()).resolves.not.toThrow();
+    });
+
+    it('保存されたトークンを復元する', async () => {
+      const savedTokens = {
+        accessToken: 'saved-token',
+        refreshToken: 'saved-refresh-token',
+        expiresAt: Date.now() + 3600000, // 1時間後
+      };
+      
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(savedTokens));
+      GoogleAuthProvider.resetInstance();
+      const provider = GoogleAuthProvider.getInstance('test-client-id');
+      
+      await provider.initialize();
+      
+      expect(provider.getAccessToken()).toBe('saved-token');
+    });
+  });
+
+  describe('isAuthenticated', () => {
+    it('有効なトークンがある場合trueを返す', async () => {
+      const tokens = {
+        accessToken: 'valid-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 3600000, // 1時間後
+      };
+      
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(tokens));
+      GoogleAuthProvider.resetInstance();
+      const provider = GoogleAuthProvider.getInstance('test-client-id');
+      
+      await provider.initialize();
+      
+      expect(provider.isAuthenticated()).toBe(true);
+    });
+
+    it('期限切れのトークンの場合falseを返す', async () => {
+      const tokens = {
+        accessToken: 'expired-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() - 3600000, // 1時間前（期限切れ）
+      };
+      
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(tokens));
+      GoogleAuthProvider.resetInstance();
+      const provider = GoogleAuthProvider.getInstance('test-client-id');
+      
+      await provider.initialize();
+      
+      expect(provider.isAuthenticated()).toBe(false);
+    });
+
+    it('トークンがない場合falseを返す', () => {
+      expect(authProvider.isAuthenticated()).toBe(false);
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('リフレッシュトークンが成功する', async () => {
+      const initialTokens = {
+        accessToken: 'old-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() - 1000, // 期限切れ
+      };
+
+      const newTokenResponse = {
+        access_token: 'new-access-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'https://www.googleapis.com/auth/drive.file',
+      };
+
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(initialTokens));
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(newTokenResponse),
+      });
+
+      GoogleAuthProvider.resetInstance();
+      const provider = GoogleAuthProvider.getInstance('test-client-id');
+      await provider.initialize();
+      
+      await provider.refreshAccessToken();
+      
+      expect(provider.getAccessToken()).toBe('new-access-token');
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'nekogata-auth-tokens',
+        expect.stringContaining('new-access-token')
+      );
+    });
+
+    it('リフレッシュトークンがない場合エラーを投げる', async () => {
+      // トークンが保存されていない状態でテスト
+      localStorageMock.getItem.mockReturnValue(null);
+      
+      GoogleAuthProvider.resetInstance();
+      const provider = GoogleAuthProvider.getInstance('test-client-id');
+      await provider.initialize();
+      
+      await expect(provider.refreshAccessToken()).rejects.toThrow('No refresh token available');
+    });
+
+    it('リフレッシュが失敗した場合トークンをクリアする', async () => {
+      const initialTokens = {
+        accessToken: 'old-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() - 1000,
+      };
+
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(initialTokens));
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.resolve({ error: 'invalid_grant' }),
+      });
+
+      GoogleAuthProvider.resetInstance();
+      const provider = GoogleAuthProvider.getInstance('test-client-id');
+      await provider.initialize();
+      
+      await expect(provider.refreshAccessToken()).rejects.toThrow();
+      expect(provider.getAccessToken()).toBeNull();
+    });
+  });
+
+  describe('validateToken', () => {
+    it('有効なトークンの場合trueを返す', async () => {
+      const tokens = {
+        accessToken: 'valid-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 3600000,
+      };
+
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(tokens));
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ aud: 'test-client-id' }),
+      });
+
+      GoogleAuthProvider.resetInstance();
+      const provider = GoogleAuthProvider.getInstance('test-client-id');
+      await provider.initialize();
+      
+      const isValid = await provider.validateToken();
+      
+      expect(isValid).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://www.googleapis.com/oauth2/v1/tokeninfo',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Authorization': 'Bearer valid-token',
+          }),
+        })
+      );
+    });
+
+    it('無効なトークンの場合falseを返しトークンをクリアする', async () => {
+      const tokens = {
+        accessToken: 'invalid-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 3600000,
+      };
+
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(tokens));
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+      });
+
+      GoogleAuthProvider.resetInstance();
+      const provider = GoogleAuthProvider.getInstance('test-client-id');
+      await provider.initialize();
+      
+      const isValid = await provider.validateToken();
+      
+      expect(isValid).toBe(false);
+      expect(provider.getAccessToken()).toBeNull();
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('nekogata-auth-tokens');
+    });
+  });
+
+  describe('signOut', () => {
+    it('トークンをリボークしローカルストレージをクリアする', async () => {
+      const tokens = {
+        accessToken: 'token-to-revoke',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 3600000,
+      };
+
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(tokens));
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      GoogleAuthProvider.resetInstance();
+      const provider = GoogleAuthProvider.getInstance('test-client-id');
+      await provider.initialize();
+      
+      provider.signOut();
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://oauth2.googleapis.com/revoke?token=token-to-revoke',
+        { method: 'POST' }
+      );
+      expect(provider.getAccessToken()).toBeNull();
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('nekogata-auth-tokens');
+    });
+  });
+});

--- a/src/utils/sync/googleAuth.ts
+++ b/src/utils/sync/googleAuth.ts
@@ -1,48 +1,69 @@
-interface GoogleAccounts {
-  oauth2: {
-    initTokenClient(config: {
-      client_id: string;
-      scope: string;
-      callback: (response: TokenResponse) => void;
-    }): TokenClient;
-    revoke(token: string): void;
-  };
+// PKCE関連の型定義
+interface PKCEState {
+  codeVerifier: string;
+  codeChallenge: string;
+  state: string;
 }
 
-interface TokenClient {
-  requestAccessToken(): void;
-  callback: (response: TokenResponse) => void;
+// OAuth 2.0レスポンスの型定義
+interface OAuthTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token?: string;
+  scope: string;
 }
 
-interface TokenResponse {
-  access_token?: string;
-  error?: string;
+interface OAuthErrorResponse {
+  error: string;
+  error_description?: string;
 }
 
+// 保存される認証情報の型定義
+interface AuthTokens {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: number;
+}
+
+// Global window interface (削除予定: 不要になったら削除)
 declare global {
   interface Window {
     google?: {
-      accounts: GoogleAccounts;
+      accounts: unknown;
     };
   }
 }
 
 export class GoogleAuthProvider {
   private static instance: GoogleAuthProvider;
-  private tokenClient: TokenClient | null = null;
-  private accessToken: string | null = null;
+  private tokens: AuthTokens | null = null;
   private isInitialized = false;
   
-  private readonly CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID || '';
+  private readonly CLIENT_ID: string;
   private readonly SCOPES = 'https://www.googleapis.com/auth/drive.file';
+  private readonly REDIRECT_URI = `${window.location.origin}/auth/callback`;
   
-  private constructor() {}
+  // OAuth 2.0エンドポイント
+  private readonly AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+  private readonly TOKEN_URL = 'https://oauth2.googleapis.com/token';
+  private readonly TOKEN_INFO_URL = 'https://www.googleapis.com/oauth2/v1/tokeninfo';
   
-  static getInstance(): GoogleAuthProvider {
+  private constructor(clientId?: string) {
+    this.CLIENT_ID = clientId || import.meta.env.VITE_GOOGLE_CLIENT_ID || '';
+  }
+  
+  static getInstance(clientId?: string): GoogleAuthProvider {
     if (!GoogleAuthProvider.instance) {
-      GoogleAuthProvider.instance = new GoogleAuthProvider();
+      GoogleAuthProvider.instance = new GoogleAuthProvider(clientId);
     }
     return GoogleAuthProvider.instance;
+  }
+
+  // テスト用のインスタンスリセットメソッド
+  static resetInstance(): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    GoogleAuthProvider.instance = undefined as any;
   }
   
   async initialize(): Promise<void> {
@@ -54,123 +75,330 @@ export class GoogleAuthProvider {
       throw new Error('Google Client ID not configured');
     }
     
-    await this.loadGoogleScript();
-    
-    this.tokenClient = window.google!.accounts.oauth2.initTokenClient({
-      client_id: this.CLIENT_ID,
-      scope: this.SCOPES,
-      callback: (response: TokenResponse) => {
-        if (response.error) {
-          throw new Error(response.error);
-        }
-        this.accessToken = response.access_token || null;
-        if (response.access_token) {
-          this.saveTokenToStorage(response.access_token);
-        }
-      },
-    });
-    
     // 保存済みトークンの復元
-    const savedToken = this.getTokenFromStorage();
-    if (savedToken) {
-      this.accessToken = savedToken;
+    const savedTokens = this.getTokensFromStorage();
+    if (savedTokens) {
+      this.tokens = savedTokens;
     }
     
     this.isInitialized = true;
   }
-  
-  private async loadGoogleScript(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      if (window.google?.accounts) {
-        resolve();
-        return;
-      }
-      
-      const script = document.createElement('script');
-      script.src = 'https://accounts.google.com/gsi/client';
-      script.async = true;
-      script.defer = true;
-      script.onload = () => resolve();
-      script.onerror = () => reject(new Error('Failed to load Google API'));
-      document.head.appendChild(script);
-    });
+
+  // PKCEユーティリティメソッド
+  private generateCodeVerifier(): string {
+    const array = new Uint8Array(32);
+    crypto.getRandomValues(array);
+    return btoa(String.fromCharCode.apply(null, Array.from(array)))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '');
+  }
+
+  private async generateCodeChallenge(verifier: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(verifier);
+    const digest = await crypto.subtle.digest('SHA-256', data);
+    return btoa(String.fromCharCode.apply(null, Array.from(new Uint8Array(digest))))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '');
+  }
+
+  private generateState(): string {
+    const array = new Uint8Array(16);
+    crypto.getRandomValues(array);
+    return btoa(String.fromCharCode.apply(null, Array.from(array)))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '');
   }
   
+  
   async authenticate(): Promise<string> {
-    return new Promise((resolve, reject) => {
-      if (this.accessToken) {
-        resolve(this.accessToken);
-        return;
+    // 有効なアクセストークンがある場合はそれを返す
+    if (this.tokens && this.isTokenValid()) {
+      return this.tokens.accessToken;
+    }
+    
+    // リフレッシュトークンがある場合は自動更新を試す
+    if (this.tokens?.refreshToken) {
+      try {
+        await this.refreshAccessToken();
+        return this.tokens.accessToken;
+      } catch (error) {
+        console.warn('Token refresh failed, starting new authentication flow:', error);
+        // リフレッシュに失敗した場合は新しい認証フローを開始
+        this.tokens = null;
+        this.removeTokensFromStorage();
       }
+    }
+    
+    // 新しい認証フローを開始
+    return this.startAuthFlow();
+  }
+
+  private async startAuthFlow(): Promise<string> {
+    const pkceState = await this.generatePKCEState();
+    
+    return new Promise((resolve, reject) => {
       
-      const originalCallback = this.tokenClient!.callback;
-      this.tokenClient!.callback = (response: TokenResponse) => {
-        originalCallback(response);
-        if (response.error) {
-          reject(new Error(response.error));
-        } else {
-          resolve(response.access_token || '');
+      // PKCE状態を一時保存
+      sessionStorage.setItem('nekogata-pkce-state', JSON.stringify(pkceState));
+      
+      // 認証URLを構築
+      const authUrl = this.buildAuthUrl(pkceState);
+      
+      // 認証コールバックリスナーを設定
+      const handleAuthCallback = async (event: MessageEvent) => {
+        if (event.origin !== window.location.origin) {
+          return;
+        }
+        
+        if (event.data.type === 'OAUTH_SUCCESS') {
+          window.removeEventListener('message', handleAuthCallback);
+          try {
+            // 認証コードをトークンに交換
+            await this.handleAuthCallback(event.data.code, event.data.state);
+            resolve(this.tokens!.accessToken);
+          } catch (error) {
+            reject(error);
+          }
+        } else if (event.data.type === 'OAUTH_ERROR') {
+          window.removeEventListener('message', handleAuthCallback);
+          reject(new Error(event.data.error));
         }
       };
       
-      this.tokenClient?.requestAccessToken();
+      window.addEventListener('message', handleAuthCallback);
+      
+      // 新しいウィンドウで認証を開始
+      const authWindow = window.open(
+        authUrl,
+        'google-auth',
+        'width=500,height=600,scrollbars=yes,resizable=yes'
+      );
+      
+      if (!authWindow) {
+        window.removeEventListener('message', handleAuthCallback);
+        reject(new Error('Failed to open authentication window'));
+        return;
+      }
+      
+      // ウィンドウが閉じられた場合の処理
+      const checkClosed = setInterval(() => {
+        if (authWindow.closed) {
+          clearInterval(checkClosed);
+          window.removeEventListener('message', handleAuthCallback);
+          reject(new Error('Authentication window was closed'));
+        }
+      }, 1000);
     });
+  }
+
+  private async generatePKCEState(): Promise<PKCEState> {
+    const codeVerifier = this.generateCodeVerifier();
+    const codeChallenge = await this.generateCodeChallenge(codeVerifier);
+    const state = this.generateState();
+    return {
+      codeVerifier,
+      codeChallenge,
+      state,
+    };
+  }
+
+  private buildAuthUrl(pkceState: PKCEState): string {
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: this.CLIENT_ID,
+      redirect_uri: this.REDIRECT_URI,
+      scope: this.SCOPES,
+      state: pkceState.state,
+      code_challenge: pkceState.codeChallenge,
+      code_challenge_method: 'S256',
+      access_type: 'offline',
+      prompt: 'consent',
+    });
+    
+    return `${this.AUTH_URL}?${params.toString()}`;
   }
   
   isAuthenticated(): boolean {
-    return !!this.accessToken;
+    return !!(this.tokens && this.isTokenValid());
+  }
+
+  private isTokenValid(): boolean {
+    if (!this.tokens) {
+      return false;
+    }
+    
+    // トークンの有効期限をチェック（5分のマージンを持たせる）
+    const now = Date.now();
+    const expiresWithMargin = this.tokens.expiresAt - (5 * 60 * 1000);
+    
+    return now < expiresWithMargin;
   }
 
   async validateToken(): Promise<boolean> {
-    if (!this.accessToken) {
+    if (!this.tokens?.accessToken) {
       return false;
     }
 
     try {
-      const response = await fetch('https://www.googleapis.com/oauth2/v1/tokeninfo', {
+      const response = await fetch(this.TOKEN_INFO_URL, {
         method: 'GET',
         headers: {
-          'Authorization': `Bearer ${this.accessToken}`,
+          'Authorization': `Bearer ${this.tokens.accessToken}`,
         },
       });
 
       if (!response.ok) {
-        this.accessToken = null;
-        this.removeTokenFromStorage();
+        this.tokens = null;
+        this.removeTokensFromStorage();
         return false;
       }
 
       return true;
     } catch (error) {
       console.error('Token validation failed:', error);
-      this.accessToken = null;
-      this.removeTokenFromStorage();
+      this.tokens = null;
+      this.removeTokensFromStorage();
       return false;
+    }
+  }
+
+  async refreshAccessToken(): Promise<void> {
+    if (!this.tokens?.refreshToken) {
+      throw new Error('No refresh token available');
+    }
+
+    try {
+      const response = await fetch(this.TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          client_id: this.CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: this.tokens.refreshToken,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData: OAuthErrorResponse = await response.json();
+        throw new Error(`Token refresh failed: ${errorData.error_description || errorData.error}`);
+      }
+
+      const tokenData: OAuthTokenResponse = await response.json();
+      
+      // 新しいトークン情報を保存
+      this.tokens = {
+        accessToken: tokenData.access_token,
+        refreshToken: tokenData.refresh_token || this.tokens.refreshToken, // 新しいリフレッシュトークンがない場合は既存のものを保持
+        expiresAt: Date.now() + (tokenData.expires_in * 1000),
+      };
+
+      this.saveTokensToStorage(this.tokens);
+    } catch (error) {
+      console.error('Failed to refresh access token:', error);
+      // リフレッシュに失敗した場合はトークンをクリア
+      this.tokens = null;
+      this.removeTokensFromStorage();
+      throw error;
     }
   }
   
   signOut(): void {
-    if (this.accessToken) {
-      window.google?.accounts.oauth2.revoke(this.accessToken);
-      this.accessToken = null;
-      this.removeTokenFromStorage();
+    if (this.tokens?.accessToken) {
+      // Googleへのリボーク要求
+      fetch(`https://oauth2.googleapis.com/revoke?token=${this.tokens.accessToken}`, {
+        method: 'POST',
+      }).catch(error => {
+        console.warn('Failed to revoke token:', error);
+      });
+      
+      this.tokens = null;
+      this.removeTokensFromStorage();
     }
   }
   
   getAccessToken(): string | null {
-    return this.accessToken;
+    return this.tokens?.accessToken || null;
   }
 
-  
-  private saveTokenToStorage(token: string): void {
-    localStorage.setItem('nekogata-google-token', token);
+  // 認証コールバック処理（新しいウィンドウから呼ばれる）
+  async handleAuthCallback(code: string, state: string): Promise<void> {
+    const savedPkceState = sessionStorage.getItem('nekogata-pkce-state');
+    if (!savedPkceState) {
+      throw new Error('PKCE state not found');
+    }
+
+    const pkceState: PKCEState = JSON.parse(savedPkceState);
+    
+    if (pkceState.state !== state) {
+      throw new Error('State mismatch');
+    }
+
+    // 認証コードをアクセストークンに交換
+    const tokenResponse = await this.exchangeCodeForTokens(code, pkceState.codeVerifier);
+    
+    // トークンを保存
+    this.tokens = {
+      accessToken: tokenResponse.access_token,
+      refreshToken: tokenResponse.refresh_token,
+      expiresAt: Date.now() + (tokenResponse.expires_in * 1000),
+    };
+
+    this.saveTokensToStorage(this.tokens);
+    
+    // PKCE状態をクリア
+    sessionStorage.removeItem('nekogata-pkce-state');
+  }
+
+  private async exchangeCodeForTokens(code: string, codeVerifier: string): Promise<OAuthTokenResponse> {
+    const response = await fetch(this.TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        client_id: this.CLIENT_ID,
+        code,
+        code_verifier: codeVerifier,
+        grant_type: 'authorization_code',
+        redirect_uri: this.REDIRECT_URI,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData: OAuthErrorResponse = await response.json();
+      throw new Error(`Token exchange failed: ${errorData.error_description || errorData.error}`);
+    }
+
+    return response.json();
   }
   
-  private getTokenFromStorage(): string | null {
-    return localStorage.getItem('nekogata-google-token');
+  private saveTokensToStorage(tokens: AuthTokens): void {
+    localStorage.setItem('nekogata-auth-tokens', JSON.stringify(tokens));
   }
   
-  private removeTokenFromStorage(): void {
+  private getTokensFromStorage(): AuthTokens | null {
+    const tokensJson = localStorage.getItem('nekogata-auth-tokens');
+    if (!tokensJson) {
+      return null;
+    }
+    
+    try {
+      return JSON.parse(tokensJson);
+    } catch (error) {
+      console.error('Failed to parse stored tokens:', error);
+      return null;
+    }
+  }
+  
+  private removeTokensFromStorage(): void {
+    localStorage.removeItem('nekogata-auth-tokens');
+    // 旧形式のトークンストレージもクリア
     localStorage.removeItem('nekogata-google-token');
   }
 }


### PR DESCRIPTION
## Summary

OAuth 2.0 Authorization Code Flow + PKCEに移行し、リフレッシュトークンによる長期間の認証状態維持を実現しました。Implicit Flowの1時間制限を解消し、最大6ヶ月の自動認証を可能にしました。

### 主な変更点
- **Authorization Code Flow + PKCE実装**: セキュアな認証フロー
- **リフレッシュトークンの取得・永続化**: 長期間の認証状態維持
- **自動リフレッシュ機能**: 5分マージン付き有効期限チェック
- **認証コールバック処理**: 新規実装（`/auth/callback.html`）
- **セキュアなトークン管理**: エラーハンドリング強化

### 技術的改善
- **UX向上**: 1時間ごとの再認証が不要（最大6ヶ月）
- **セキュリティ強化**: PKCEによる認証フロー保護
- **エラー処理**: リフレッシュ失敗時の適切なフォールバック

### ファイル変更
- `src/utils/sync/googleAuth.ts`: 完全リニューアル（Authorization Code Flow + PKCE）
- `src/utils/sync/__tests__/googleAuth.test.ts`: 包括的なユニットテスト追加
- `public/auth/callback.html`: 認証コールバック処理ページ

## Test plan

- [x] **ユニットテスト**: 12/12 成功 - 全機能の動作確認
- [x] **E2Eテスト**: 178/178 成功 - 全ブラウザ対応確認
- [x] **Lint**: エラーなし - コード品質確認
- [x] **Build**: 成功 - 本番ビルド確認
- [x] **既存機能**: すべて正常動作確認

### 手動テスト項目
- [ ] 新規認証フローの動作確認
- [ ] リフレッシュトークンによる自動更新確認
- [ ] エラー時のフォールバック確認

🤖 Generated with [Claude Code](https://claude.ai/code)