### PR TITLE
feat: Netlifyでのコールバックパスルーティング設定を追加

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,6 +23,13 @@
   VITE_LOG_LEVEL = "DEBUG"
 
 # リダイレクト設定（SPAサポート）
+# OAuth認証コールバック
+[[redirects]]
+  from = "/auth/callback"
+  to = "/auth/callback.html"
+  status = 200
+
+# SPAフォールバック（最後に評価される）
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
## Summary
- `/auth/callback`へのアクセスを`/auth/callback.html`に内部ルーティングする設定を追加
- `netlify.toml`でSPAフォールバックより先に評価されるよう設定
- クエリストリング付きのリクエストにも対応（OAuth認証フローで必須）

## Test plan
- [ ] Netlifyデプロイ後に `/auth/callback` パスが正常に動作することを確認
- [ ] `/auth/callback?code=xxx&state=yyy` のようなクエリストリング付きアクセスでも正しく`callback.html`が表示されることを確認
- [ ] OAuth認証フローが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)