### PR TITLE
fix: Service Workerの認証コールバックキャッシュ問題を修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,9 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
         runtimeCaching: [
           {
-            urlPattern: ({ request }) => request.destination === 'document',
+            urlPattern: ({ request, url }) => 
+              request.destination === 'document' && 
+              !url.pathname.startsWith('/auth/'),
             handler: 'NetworkFirst',
             options: {
               cacheName: 'documents',


### PR DESCRIPTION
## Summary
- Service Workerが`/auth/callback`をキャッシュしてしまい、初回アクセス時にSPAのindex.htmlが返される問題を修正
- `/auth/`で始まるパスをドキュメントキャッシュから除外

## 問題の詳細
認証フロー中、コールバックURLへの初回アクセス時にService WorkerがSPAのindex.htmlを返してしまい、リロードするまで正しいcallback.htmlが表示されない問題がありました。

## Test plan
- [ ] ビルド後、認証フローが正常に動作することを確認
- [ ] `/auth/callback`への初回アクセスでcallback.htmlが正しく表示されることを確認
- [ ] Service Workerが更新され、古いキャッシュがクリアされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)