### PR TITLE
Debug: サービスワーカーを一時的に無効化してOAuth問題を切り分け

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { VitePWA } from 'vite-plugin-pwa'
+//import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -13,72 +13,72 @@ export default defineConfig({
   },
   plugins: [
     react(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
-      workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
-        runtimeCaching: [
-          {
-            urlPattern: ({ request, url }) => 
-              request.destination === 'document' && 
-              !url.pathname.startsWith('/auth/'),
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'documents',
-              networkTimeoutSeconds: 3,
-              expiration: {
-                maxEntries: 10,
-                maxAgeSeconds: 24 * 60 * 60 // 24 hours
-              }
-            }
-          },
-          {
-            urlPattern: ({ request }) => 
-              request.destination === 'script' || 
-              request.destination === 'style',
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'assets',
-              networkTimeoutSeconds: 3,
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 24 * 60 * 60 // 24 hours
-              }
-            }
-          },
-          {
-            urlPattern: ({ request }) => request.destination === 'image',
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'images',
-              networkTimeoutSeconds: 3,
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 30 * 24 * 60 * 60 // 30 days
-              }
-            }
-          }
-        ]
-      },
-      manifest: {
-        name: 'Nekogata Score Manager',
-        short_name: 'NekogataScore',
-        description: 'コード譜の作成・閲覧・管理ができるアプリケーション',
-        theme_color: '#ffffff',
-        icons: [
-          {
-            src: 'pwa-192x192.png',
-            sizes: '192x192',
-            type: 'image/png'
-          },
-          {
-            src: 'pwa-512x512.png',
-            sizes: '512x512',
-            type: 'image/png'
-          }
-        ]
-      }
-    })
+    //VitePWA({
+    //  registerType: 'autoUpdate',
+    //  includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
+    //  workbox: {
+    //    globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+    //    runtimeCaching: [
+    //      {
+    //        urlPattern: ({ request, url }) => 
+    //          request.destination === 'document' && 
+    //          !url.pathname.startsWith('/auth/'),
+    //        handler: 'NetworkFirst',
+    //        options: {
+    //          cacheName: 'documents',
+    //          networkTimeoutSeconds: 3,
+    //          expiration: {
+    //            maxEntries: 10,
+    //            maxAgeSeconds: 24 * 60 * 60 // 24 hours
+    //          }
+    //        }
+    //      },
+    //      {
+    //        urlPattern: ({ request }) => 
+    //          request.destination === 'script' || 
+    //          request.destination === 'style',
+    //        handler: 'NetworkFirst',
+    //        options: {
+    //          cacheName: 'assets',
+    //          networkTimeoutSeconds: 3,
+    //          expiration: {
+    //            maxEntries: 50,
+    //            maxAgeSeconds: 24 * 60 * 60 // 24 hours
+    //          }
+    //        }
+    //      },
+    //      {
+    //        urlPattern: ({ request }) => request.destination === 'image',
+    //        handler: 'NetworkFirst',
+    //        options: {
+    //          cacheName: 'images',
+    //          networkTimeoutSeconds: 3,
+    //          expiration: {
+    //            maxEntries: 50,
+    //            maxAgeSeconds: 30 * 24 * 60 * 60 // 30 days
+    //          }
+    //        }
+    //      }
+    //    ]
+    //  },
+    //  manifest: {
+    //    name: 'Nekogata Score Manager',
+    //    short_name: 'NekogataScore',
+    //    description: 'コード譜の作成・閲覧・管理ができるアプリケーション',
+    //    theme_color: '#ffffff',
+    //    icons: [
+    //      {
+    //        src: 'pwa-192x192.png',
+    //        sizes: '192x192',
+    //        type: 'image/png'
+    //      },
+    //      {
+    //        src: 'pwa-512x512.png',
+    //        sizes: '512x512',
+    //        type: 'image/png'
+    //      }
+    //    ]
+    //  }
+    //})
   ],
 })


### PR DESCRIPTION
## Summary
- OAuthコールバック時にアプリが表示される問題の原因特定のため、サービスワーカーを一時的に無効化
- vite.config.tsでVitePWAプラグインをコメントアウト

## 背景
OAuthのコールバックURL（`/auth/callback`）にアクセスした際、初回はアプリが表示されてしまうが、リロードすると正しくコールバックページが表示される問題が発生している。

サービスワーカーのキャッシュが原因の可能性があるため、一時的にサービスワーカーを無効化して問題の切り分けを行う。

## Test plan
- [ ] Netlifyにデプロイ後、ブラウザのキャッシュをクリア
- [ ] Google認証フローを実行
- [ ] コールバックURLが正しく処理されることを確認
- [ ] 問題が解決した場合、サービスワーカーの設定修正が必要

🤖 Generated with [Claude Code](https://claude.ai/code)