### PR TITLE
Debug: OAuth PKCEフローの詳細ログ追加とコールバック調査

### DIFF
--- a/OAUTH_DEBUG.md
+++ b/OAUTH_DEBUG.md
@@ -1,0 +1,50 @@
+# OAuth デバッグガイド
+
+## 現在の問題
+- `client_secret is missing` エラーが発生
+- PKCEフローを使用しているのに、client_secretが要求されている
+
+## デバッグログの確認方法
+
+1. ブラウザの開発者ツールを開く
+2. Consoleタブで以下のログを確認：
+   - `Auth URL params:` - 認証リクエストのパラメータ
+   - `Token exchange request:` - トークン交換リクエストの詳細
+   - `Token exchange error:` - エラーの詳細情報
+
+## Google Cloud Console で確認すべき項目
+
+1. **OAuth 2.0 クライアントの種類**
+   - 「ウェブアプリケーション」が選択されているか確認
+   - 「シングルページアプリケーション」や「公開クライアント」の設定があるか確認
+
+2. **承認済みのリダイレクト URI**
+   - 本番環境: `https://your-domain.netlify.app/auth/callback`
+   - 開発環境: `http://localhost:5173/auth/callback`
+   - 末尾のスラッシュの有無に注意
+
+3. **PKCE サポート**
+   - Google OAuth 2.0 の設定で PKCE が有効になっているか確認
+   - クライアントの種類によってはPKCEがサポートされない場合がある
+
+## 可能な解決策
+
+### 1. クライアントタイプの確認
+Google Cloud Consoleで、OAuth 2.0クライアントが「ウェブアプリケーション」として設定されている場合、PKCEを使わない通常のフローに切り替える必要があるかもしれません。
+
+### 2. Implicit Flow への切り替え
+SPAの場合、以下のようにImplicit Flowを使用する方法もあります：
+```typescript
+// response_type を 'token' に変更
+response_type: 'token',
+// code_challenge と code_challenge_method を削除
+```
+
+### 3. Google Identity Services への移行
+新しいGoogle Identity Services (GIS) ライブラリを使用する方法も検討できます。
+
+## 次のステップ
+
+1. デバッグログを確認して、実際に送信されているパラメータを確認
+2. Google Cloud Console の設定を確認
+3. 必要に応じて認証フローを調整

--- a/public/auth/callback.html
+++ b/public/auth/callback.html
@@ -50,11 +50,21 @@
 
     <script>
         (async function() {
+            console.log('OAuth callback started');
+            console.log('Current URL:', window.location.href);
+            console.log('Window opener:', window.opener);
+            
             try {
                 const urlParams = new URLSearchParams(window.location.search);
                 const code = urlParams.get('code');
                 const state = urlParams.get('state');
                 const error = urlParams.get('error');
+
+                console.log('URL params:', {
+                    code: code ? `${code.substring(0, 10)}...` : null,
+                    state: state,
+                    error: error
+                });
 
                 if (error) {
                     throw new Error(`認証エラー: ${error}`);
@@ -66,13 +76,25 @@
 
                 // 親ウィンドウに成功を通知
                 if (window.opener) {
-                    window.opener.postMessage({
+                    console.log('Sending message to opener window');
+                    const message = {
                         type: 'OAUTH_SUCCESS',
                         code: code,
                         state: state
-                    }, window.location.origin);
-                    window.close();
+                    };
+                    console.log('Message to send:', {
+                        type: message.type,
+                        codeLength: code.length,
+                        state: state
+                    });
+                    
+                    window.opener.postMessage(message, window.location.origin);
+                    console.log('Message sent, closing window');
+                    // デバッグ中はウィンドウを閉じない
+                    console.log('DEBUG: Window close is disabled for debugging');
+                    // window.close();
                 } else {
+                    console.log('No opener window, redirecting to main page');
                     // 直接アクセスされた場合はメインページにリダイレクト
                     window.location.href = '/';
                 }
@@ -90,10 +112,12 @@
                         error: error.message
                     }, window.location.origin);
                     
+                    // デバッグ中はウィンドウを閉じない
+                    console.log('DEBUG: Auto-close is disabled for debugging');
                     // 5秒後にウィンドウを閉じる
-                    setTimeout(() => {
-                        window.close();
-                    }, 5000);
+                    // setTimeout(() => {
+                    //     window.close();
+                    // }, 5000);
                 }
             }
         })();


### PR DESCRIPTION
## Summary
- OAuth認証で`client_secret is missing`エラーが発生する問題の調査
- PKCE認証フロー全体に詳細なデバッグログを追加
- コールバックウィンドウを閉じないよう修正してログ確認を可能に

## 背景
サービスワーカーを無効化してもOAuth認証時に`client_secret is missing`エラーが発生。
PKCEフローが正しく動作しているかを詳細に調査するため、認証フロー全体にログを追加。

## 追加したデバッグ機能

### 1. 認証URL生成時のログ
- Client ID、リダイレクトURI の確認
- Code challenge、Code verifier の長さ確認

### 2. コールバックページでの詳細ログ
- URLパラメータの解析結果
- postMessage送信の詳細
- ウィンドウクローズを無効化してログ確認を可能に

### 3. SPA側でのメッセージ受信ログ
- postMessage受信時の詳細情報
- トークン交換リクエストの詳細
- エラーレスポンスの完全な情報

## Test plan
- [ ] Netlifyにデプロイ後、ブラウザでGoogle認証を実行
- [ ] 各段階でコンソールログを確認
- [ ] `client_secret is missing`エラーがどの段階で発生するかを特定
- [ ] Google Cloud Console設定との照合

🤖 Generated with [Claude Code](https://claude.ai/code)