### PR TITLE
fix: auth/callback.htmlのサービスワーカーキャッシュ問題を修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,18 +18,21 @@ export default defineConfig({
       includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+        globIgnores: ['**/auth/**'],
+        navigateFallback: null,
         // サービスワーカーを常に最新に保つ設定
         skipWaiting: true,
         clientsClaim: true,
         cleanupOutdatedCaches: true,
         runtimeCaching: [
           {
-            // auth以下は完全にキャッシュしない
+            // auth以下は完全にキャッシュしない（最優先）
             urlPattern: ({ url }) => url.pathname.startsWith('/auth/'),
             handler: 'NetworkOnly'
           },
           {
             // ドキュメント: ネットワーク優先、タイムアウトなし（失敗時のみキャッシュ使用）
+            // auth以下は除外
             urlPattern: ({ request, url }) => 
               request.destination === 'document' && 
               !url.pathname.startsWith('/auth/'),


### PR DESCRIPTION
## Summary
- クエリストリング付きのauth/callback.htmlでメインアプリが表示される問題を修正
- サービスワーカーがauth関連ファイルをprecacheしないよう設定を変更
- NavigateFallback機能を無効化してSPAのフォールバック動作を停止

## 変更内容
- `globIgnores: ['**/auth/**']` を追加してauth以下をprecacheから除外
- `navigateFallback: null` でSPAフォールバック機能を無効化  
- runtimeCachingの設定順序とコメントを調整

## Test plan
- [ ] `https://nekogata-score-manager.netlify.app/auth/callback.html` で正しくコールバックページが表示されることを確認
- [ ] `https://nekogata-score-manager.netlify.app/auth/callback.html?code=test&state=test` でもコールバックページが表示されることを確認
- [ ] リロード時も正しく動作することを確認

🤖Generated with [Claude Code](https://claude.ai/code)