### PR TITLE
refactor: コード入力パース機能を統一的に共通化

### DIFF
--- a/src/hooks/__tests__/useChordOperations.test.ts
+++ b/src/hooks/__tests__/useChordOperations.test.ts
@@ -8,6 +8,7 @@ import * as chordParsing from '../../utils/chordParsing';
 vi.mock('../../utils/chordParsing', () => ({
   extractChordRoot: vi.fn(),
   parseOnChord: vi.fn(),
+  parseChordInput: vi.fn(),
 }));
 
 vi.mock('../../utils/lineBreakHelpers', () => ({
@@ -108,11 +109,16 @@ describe('useChordOperations', () => {
   });
 
   it('finalizeChordNameがコード名をパースして更新する', () => {
-    const mockParseOnChord = vi.mocked(chordParsing.parseOnChord);
-    const mockExtractChordRoot = vi.mocked(chordParsing.extractChordRoot);
+    const mockParseChordInput = vi.mocked(chordParsing.parseChordInput);
     
-    mockParseOnChord.mockReturnValue({ chord: 'Am', base: 'C' });
-    mockExtractChordRoot.mockReturnValue('A');
+    // parseChordInputが期待するオブジェクトを返すようにモック
+    mockParseChordInput.mockReturnValue({
+      name: 'Am',
+      root: 'A',
+      base: 'C',
+      duration: 4,
+      memo: ''
+    });
 
     const { result } = renderUseChordOperations();
 
@@ -120,8 +126,7 @@ describe('useChordOperations', () => {
       result.current.finalizeChordName('section-1', 0, 'Am/C');
     });
 
-    expect(mockParseOnChord).toHaveBeenCalledWith('Am/C');
-    expect(mockExtractChordRoot).toHaveBeenCalledWith('Am');
+    expect(mockParseChordInput).toHaveBeenCalledWith('Am/C', 4); // デフォルト拍数4で呼び出される
     expect(mockOnUpdateChart).toHaveBeenCalledWith({
       ...mockChart,
       sections: [

--- a/src/hooks/useChordOperations.ts
+++ b/src/hooks/useChordOperations.ts
@@ -1,5 +1,5 @@
 import type { ChordChart, Chord } from '../types';
-import { extractChordRoot, parseOnChord } from '../utils/chordParsing';
+import { parseChordInput } from '../utils/chordParsing';
 import { createLineBreakMarker } from '../utils/lineBreakHelpers';
 
 interface UseChordOperationsProps {
@@ -64,7 +64,15 @@ export const useChordOperations = ({
       return;
     }
     
-    const parsed = parseOnChord(value);
+    // 既存のコードの拍数をデフォルトとして使用
+    const currentChord = chart.sections?.find(s => s.id === sectionId)?.chords[chordIndex];
+    const defaultDuration = currentChord?.duration || 4;
+    
+    const parsed = parseChordInput(value, defaultDuration);
+    if (!parsed) {
+      return; // パースに失敗した場合は何もしない
+    }
+    
     const updatedChart = {
       ...chart,
       sections: chart.sections?.map(section =>
@@ -75,9 +83,10 @@ export const useChordOperations = ({
                 if (index === chordIndex) {
                   return {
                     ...chord,
-                    name: parsed.chord,
-                    root: extractChordRoot(parsed.chord),
-                    base: parsed.base
+                    name: parsed.name,
+                    root: parsed.root,
+                    base: parsed.base,
+                    duration: parsed.duration
                   };
                 }
                 return chord;

--- a/src/utils/__tests__/chordParsing.test.ts
+++ b/src/utils/__tests__/chordParsing.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import { 
+  extractChordRoot, 
+  parseOnChord, 
+  isOnChord,
+  parseChordInput
+} from '../chordParsing';
+
+describe('chordParsing', () => {
+  describe('extractChordRoot', () => {
+    it('should extract root from simple chords', () => {
+      expect(extractChordRoot('C')).toBe('C');
+      expect(extractChordRoot('Am')).toBe('A');
+      expect(extractChordRoot('F#')).toBe('F#');
+      expect(extractChordRoot('Bb')).toBe('B♭');
+      expect(extractChordRoot('D♭')).toBe('D♭');
+    });
+
+    it('should handle complex chord names', () => {
+      expect(extractChordRoot('C7')).toBe('C');
+      expect(extractChordRoot('Am7')).toBe('A');
+      expect(extractChordRoot('F#maj7')).toBe('F#');
+      expect(extractChordRoot('Bbm7(b5)')).toBe('B♭');
+    });
+
+    it('should return default for invalid input', () => {
+      expect(extractChordRoot('')).toBe('C');
+      expect(extractChordRoot('invalid')).toBe('C');
+    });
+  });
+
+  describe('parseOnChord', () => {
+    it('should parse on-chords correctly', () => {
+      expect(parseOnChord('C/E')).toEqual({ chord: 'C', base: 'E' });
+      expect(parseOnChord('Am7/G')).toEqual({ chord: 'Am7', base: 'G' });
+      expect(parseOnChord('F#m/C#')).toEqual({ chord: 'F#m', base: 'C#' });
+      expect(parseOnChord('Bb/D')).toEqual({ chord: 'Bb', base: 'D' });
+    });
+
+    it('should handle non-on-chords', () => {
+      expect(parseOnChord('C')).toEqual({ chord: 'C' });
+      expect(parseOnChord('Am7')).toEqual({ chord: 'Am7' });
+    });
+
+    it('should normalize flat symbols', () => {
+      expect(parseOnChord('Bb/Db')).toEqual({ chord: 'Bb', base: 'D♭' });
+    });
+  });
+
+  describe('isOnChord', () => {
+    it('should identify on-chords correctly', () => {
+      expect(isOnChord('C/E')).toBe(true);
+      expect(isOnChord('Am7/G')).toBe(true);
+      expect(isOnChord('F#m/C#')).toBe(true);
+    });
+
+    it('should identify non-on-chords correctly', () => {
+      expect(isOnChord('C')).toBe(false);
+      expect(isOnChord('Am7')).toBe(false);
+      expect(isOnChord('F#m')).toBe(false);
+    });
+  });
+
+  describe('parseChordInput', () => {
+    describe('duration syntax [n]', () => {
+      it('should parse chords with integer duration', () => {
+        const result = parseChordInput('C[2]');
+        expect(result).toEqual({
+          name: 'C',
+          root: 'C',
+          duration: 2,
+          memo: ''
+        });
+      });
+
+      it('should parse chords with decimal duration', () => {
+        const result = parseChordInput('Am[1.5]');
+        expect(result).toEqual({
+          name: 'Am',
+          root: 'A',
+          duration: 1.5,
+          memo: ''
+        });
+      });
+
+      it('should parse complex chords with duration', () => {
+        const result = parseChordInput('E7(#9)[2]');
+        expect(result).toEqual({
+          name: 'E7(#9)',
+          root: 'E',
+          duration: 2,
+          memo: ''
+        });
+      });
+
+      it('should parse on-chords with duration', () => {
+        const result = parseChordInput('C/E[4]');
+        expect(result).toEqual({
+          name: 'C',
+          root: 'C',
+          base: 'E',
+          duration: 4,
+          memo: ''
+        });
+      });
+
+      it('should reject invalid durations', () => {
+        expect(parseChordInput('C[0]')).toBeNull();
+        expect(parseChordInput('C[-1]')).toBeNull();
+        expect(parseChordInput('C[17]')).toBeNull();
+        expect(parseChordInput('C[abc]')).toBeNull();
+      });
+    });
+
+    describe('default duration', () => {
+      it('should use default duration when no duration specified', () => {
+        const result = parseChordInput('C', 8);
+        expect(result).toEqual({
+          name: 'C',
+          root: 'C',
+          duration: 8,
+          memo: ''
+        });
+      });
+
+      it('should use default duration of 4 when not specified', () => {
+        const result = parseChordInput('Am');
+        expect(result).toEqual({
+          name: 'Am',
+          root: 'A',
+          duration: 4,
+          memo: ''
+        });
+      });
+    });
+
+    describe('complex chord names', () => {
+      it('should parse various chord types', () => {
+        const testCases = [
+          { input: 'Cmaj7', expected: { name: 'Cmaj7', root: 'C' } },
+          { input: 'Am7', expected: { name: 'Am7', root: 'A' } },
+          { input: 'F#m', expected: { name: 'F#m', root: 'F#' } },
+          { input: 'Bb7', expected: { name: 'Bb7', root: 'B♭' } },
+          { input: 'Ddim', expected: { name: 'Ddim', root: 'D' } },
+          { input: 'Gaug', expected: { name: 'Gaug', root: 'G' } },
+          { input: 'Csus4', expected: { name: 'Csus4', root: 'C' } },
+          { input: 'Asus2', expected: { name: 'Asus2', root: 'A' } },
+          { input: 'Cadd9', expected: { name: 'Cadd9', root: 'C' } }
+        ];
+
+        for (const { input, expected } of testCases) {
+          const result = parseChordInput(input);
+          expect(result?.name).toBe(expected.name);
+          expect(result?.root).toBe(expected.root);
+          expect(result?.duration).toBe(4);
+        }
+      });
+
+      it('should parse tension chords', () => {
+        const result = parseChordInput('C7(b5)');
+        expect(result).toEqual({
+          name: 'C7(b5)',
+          root: 'C',
+          duration: 4,
+          memo: ''
+        });
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle empty or invalid input', () => {
+        expect(parseChordInput('')).toBeNull();
+        expect(parseChordInput('   ')).toBeNull();
+        expect(parseChordInput('invalid')).toBeNull();
+        expect(parseChordInput('123')).toBeNull();
+      });
+
+      it('should normalize flat symbols', () => {
+        const result = parseChordInput('Bb/Db[2]');
+        expect(result).toEqual({
+          name: 'Bb',
+          root: 'B♭',
+          base: 'D♭',
+          duration: 2,
+          memo: ''
+        });
+      });
+    });
+
+    describe('integration with existing functionality', () => {
+      it('should work with textToChords patterns', () => {
+        // 一括入力でよく使われるパターンをテスト
+        const patterns = [
+          'C[4]',
+          'F[2]',
+          'G[2]',
+          'Am[4]',
+          'E7(#9)[2]',
+          'C/E[1.5]'
+        ];
+
+        for (const pattern of patterns) {
+          const result = parseChordInput(pattern);
+          expect(result).not.toBeNull();
+          expect(typeof result?.duration).toBe('number');
+          expect(result?.duration).toBeGreaterThan(0);
+        }
+      });
+
+      it('should work with single chord input patterns', () => {
+        // 個別入力でよく使われるパターンをテスト
+        const patterns = [
+          'C',
+          'Am',
+          'F#m',
+          'Bb7',
+          'C/E',
+          'Am7/G'
+        ];
+
+        for (const pattern of patterns) {
+          const result = parseChordInput(pattern);
+          expect(result).not.toBeNull();
+          expect(result?.duration).toBe(4); // デフォルト拍数
+        }
+      });
+    });
+  });
+});

--- a/src/utils/chordCopyPaste.ts
+++ b/src/utils/chordCopyPaste.ts
@@ -1,5 +1,5 @@
 import type { Chord } from '../types';
-import { extractChordRoot, parseOnChord } from './chordParsing';
+import { parseChordInput } from './chordParsing';
 
 /**
  * コード進行を文字列形式に変換する
@@ -77,50 +77,7 @@ export const textToChords = (text: string): Chord[] => {
  * @returns パースされたコード、またはnull
  */
 const parseChordText = (text: string): Chord | null => {
-  // [拍数]記法をチェック（オンコード対応）
-  const bracketMatch = text.match(/^([A-G][#b♭]?(?:maj|min|m|dim|aug|sus[24]|add\d+|\d+)*(?:\([#b♭]?\d+\))*(?:\/[A-G][#b♭]?)?)\[(\d*\.?\d*)\]$/i);
-  if (bracketMatch) {
-    const [, fullChordName, durationStr] = bracketMatch;
-    const duration = durationStr ? parseFloat(durationStr) : 4;
-    
-    // 無効な拍数をチェック
-    if (isNaN(duration) || duration <= 0 || duration > 16) {
-      return null;
-    }
-    
-    // オンコード解析
-    const parsed = parseOnChord(fullChordName);
-    const root = extractChordRoot(parsed.chord);
-    
-    return {
-      name: parsed.chord,
-      root,
-      base: parsed.base,
-      duration,
-      memo: ''
-    };
-  }
-  
-  // 拍数指定なしのコード名のみ（テンションコード・オンコード含む）
-  const basicMatch = text.match(/^([A-G][#b♭]?(?:maj|min|m|dim|aug|sus[24]|add\d+|\d+)*(?:\([#b♭]?\d+\))*(?:\/[A-G][#b♭]?)?)$/i);
-  if (basicMatch) {
-    const [, fullChordName] = basicMatch;
-    const duration = 4;
-    
-    // オンコード解析
-    const parsed = parseOnChord(fullChordName);
-    const root = extractChordRoot(parsed.chord);
-    
-    return {
-      name: parsed.chord,
-      root,
-      base: parsed.base,
-      duration,
-      memo: ''
-    };
-  }
-  
-  return null;
+  return parseChordInput(text, 4);
 };
 
 /**


### PR DESCRIPTION
## Summary

個別入力、一括入力、コピペの3つの入力フローで使用されていたコードパース処理を統一的な関数に共通化しました。

- 新しい`parseChordInput`関数で拍数指定記法`[n]`に完全対応
- 個別入力でも`C[2]`, `Am[1.5]`形式での拍数指定が可能に
- 重複していたパース処理ロジックを削除してメンテナンス性向上

## Test plan

- [x] 新しい`parseChordInput`関数の単体テスト（21テストケース）
- [x] 既存の全テストスイート実行（656テスト通過）
- [x] ESLintでコード品質確認
- [x] TypeScriptビルド確認

🤖 Generated with [Claude Code](https://claude.ai/code)