### PR TITLE
譜面表示画面のレイアウト最適化 - スペース効率向上

### DIFF
--- a/src/components/ChordChartViewer.tsx
+++ b/src/components/ChordChartViewer.tsx
@@ -14,10 +14,10 @@ interface ChordChartViewerProps {
 const ChordChartViewer: React.FC<ChordChartViewerProps> = ({ chart, currentChartId, onEdit }) => {
   return (
     <div className="h-full bg-white overflow-y-auto" data-testid="chart-viewer">
-      <div className="p-6">
-        <div className="mb-6">
-          <h2 className="text-2xl font-bold text-slate-900 mb-2" data-testid="chart-title">{chart.title}</h2>
-          <div className="flex flex-wrap gap-4 text-slate-600">
+      <div className="p-3">
+        <div className="mb-3">
+          <h2 className="text-xl font-bold text-slate-900 mb-1" data-testid="chart-title">{chart.title}</h2>
+          <div className="flex flex-wrap gap-3 text-sm text-slate-600">
             <span data-testid="chart-artist">{chart.artist}</span>
             <span data-testid="chart-key">キー: {KEY_DISPLAY_NAMES[chart.key] || chart.key}</span>
             {chart.tempo && <BpmIndicator bpm={chart.tempo} />}
@@ -34,12 +34,12 @@ const ChordChartViewer: React.FC<ChordChartViewerProps> = ({ chart, currentChart
           )}
         </div>
 
-        <div className="bg-slate-50 rounded-lg p-3 sm:p-6" data-testid="chart-content">
+        <div className="bg-slate-50 rounded-lg p-2" data-testid="chart-content">
           {chart.sections && chart.sections.length > 0 ? (
             chart.sections.map((section) => (
-              <div key={section.id} className="mb-8 last:mb-0" data-testid={`section-${section.id}`}>
+              <div key={section.id} className="mb-3 last:mb-0" data-testid={`section-${section.id}`}>
                 {section.name && (
-                  <h3 className="text-sm font-medium text-slate-600 mb-1" data-testid={`section-name-${section.id}`}>
+                  <h3 className="text-xs font-medium text-slate-600 mb-0.5" data-testid={`section-name-${section.id}`}>
                     【{section.name}】
                   </h3>
                 )}
@@ -55,9 +55,9 @@ const ChordChartViewer: React.FC<ChordChartViewerProps> = ({ chart, currentChart
         </div>
 
         {chart.notes && (
-          <div className="mt-6 p-4 bg-yellow-50 rounded-lg border border-yellow-200" data-testid="chart-notes">
-            <h4 className="font-semibold text-slate-800 mb-2">メモ</h4>
-            <p className="text-slate-700">{chart.notes}</p>
+          <div className="mt-3 p-2 bg-yellow-50 rounded-lg border border-yellow-200" data-testid="chart-notes">
+            <h4 className="text-sm font-semibold text-slate-800 mb-1">メモ</h4>
+            <p className="text-sm text-slate-700">{chart.notes}</p>
           </div>
         )}
 

--- a/src/components/ChordGridRenderer.tsx
+++ b/src/components/ChordGridRenderer.tsx
@@ -56,7 +56,7 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({ section, timeSign
       {processedRows.map((rowBars, rowIndex) => (
         <div key={rowIndex}>
           <div className="relative bg-white">
-            <div className="flex min-h-12 py-1">
+            <div className="flex min-h-8 py-0.5">
               {rowBars.map((bar, barIndex) => (
                 <div 
                   key={barIndex} 
@@ -68,10 +68,10 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({ section, timeSign
                   }}
                 >
                   {barIndex > 0 && (
-                    <div className="absolute left-0 top-3 bottom-3 w-0.5 bg-slate-600"></div>
+                    <div className="absolute left-0 top-2 bottom-2 w-0.5 bg-slate-600"></div>
                   )}
                   
-                  <div className="px-1 py-1 h-full flex items-center">
+                  <div className="px-0.5 py-0.5 h-full flex items-center">
                     {bar.map((chord, chordIndex) => {
                       const chordDuration = chord.duration || 4;
                       const widthPercentage = (chordDuration / beatsPerBar) * 100;
@@ -79,11 +79,11 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({ section, timeSign
                       return (
                         <div 
                           key={chordIndex} 
-                          className="flex flex-col justify-center hover:bg-slate-100 cursor-pointer rounded px-1"
+                          className="flex flex-col justify-center hover:bg-slate-100 cursor-pointer rounded px-0.5"
                           style={{ width: `${widthPercentage}%` }}
                         >
                           <div className="text-left flex items-center">
-                            <span className="text-xs font-semibold">
+                            <span className="text-xs font-medium leading-none">
                               {chord.name}
                               {chord.base && (
                                 <span className="text-slate-500">/{chord.base}</span>
@@ -91,7 +91,7 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({ section, timeSign
                             </span>
                           </div>
                           {chord.memo && (
-                            <div className="text-left text-xs text-slate-600 leading-tight mt-0.5">
+                            <div className="text-left text-[10px] text-slate-600 leading-tight">
                               {chord.memo}
                             </div>
                           )}
@@ -101,13 +101,13 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({ section, timeSign
                   </div>
                   
                   {barIndex === rowBars.length - 1 && (
-                    <div className="absolute right-0 top-3 bottom-3 w-0.5 bg-slate-600"></div>
+                    <div className="absolute right-0 top-2 bottom-2 w-0.5 bg-slate-600"></div>
                   )}
                 </div>
               ))}
             </div>
             
-            <div className="absolute left-0 top-4 bottom-4 w-0.5 bg-slate-600"></div>
+            <div className="absolute left-0 top-2 bottom-2 w-0.5 bg-slate-600"></div>
           </div>
         </div>
       ))}

--- a/src/components/__tests__/ChordGridRenderer.test.tsx
+++ b/src/components/__tests__/ChordGridRenderer.test.tsx
@@ -183,7 +183,7 @@ describe('ChordGridRenderer', () => {
       expect(gridElements.length).toBeGreaterThan(0);
 
       // Check for flex layout
-      const flexElements = container.querySelectorAll('.flex.min-h-12');
+      const flexElements = container.querySelectorAll('.flex.min-h-8');
       expect(flexElements.length).toBeGreaterThan(0);
     });
 


### PR DESCRIPTION
## 概要
スタジオでの実使用時に、演奏中の譜めくり頻度を減らすため、譜面表示画面のレイアウトを最適化しました。

## 変更内容
### スペース削減の実装
- **セクション間の余白**: 32px → 12px に削減
- **全体のパディング**: 24px → 12px に縮小  
- **コード行の高さ**: 48px → 32px に調整
- **コード名のフォントサイズ**: 適度に調整し、メモは10pxに
- **セクション名**: 12px に変更

### 効果
- より多くのコード情報を一画面に表示可能
- 紙のコード譜（A4）と同等のスペース効率を実現
- 演奏中の譜めくり回数を大幅に削減

## テスト
- [x] ユニットテスト全て通過
- [x] ビルド成功
- [x] lint エラーなし

## 背景
実際にスタジオで使用した際、通常の長さの曲でも複数回のスクロールが必要だったため、
紙のコード譜（A4一枚）と同等のスペース効率を目指して改善しました。

🤖 Generated with [Claude Code](https://claude.ai/code)