### PR TITLE
improve: スリープ防止ボタンのUIを改善

### DIFF
--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -47,29 +47,30 @@ const Header: React.FC<HeaderProps> = ({ explorerOpen, setExplorerOpen }) => {
             </div>
           )}
           {wakeLockSupported && (
-            <button
-              onClick={toggleWakeLock}
-              className={`px-3 py-2 rounded-md border text-sm font-medium transition-all duration-150 shadow-sm ${
-                wakeLockActive
-                  ? 'bg-[#85B0B7] hover:bg-[#6B9CA5] text-white border-[#85B0B7]'
-                  : 'bg-slate-100 hover:bg-slate-200 text-slate-600 border-slate-300'
-              }`}
-              title={wakeLockActive ? 'スリープ防止を無効にする' : 'スリープ防止を有効にする'}
-              data-testid="wake-lock-button"
-            >
-              <span className="flex items-center gap-2">
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  {wakeLockActive ? (
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-                  ) : (
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-                  )}
-                </svg>
-                <span className="hidden sm:inline">
-                  {wakeLockActive ? 'スリープ防止中' : 'スリープ防止'}
+            <div className="flex items-center gap-2" data-testid="wake-lock-button">
+              <span className="text-sm text-slate-700 flex items-center gap-1">
+                <span className="font-mono relative">
+                  Zzz
+                  <span className="absolute inset-0 flex items-center justify-center">
+                    <span className="w-4 h-0.5 bg-current transform rotate-45"></span>
+                  </span>
                 </span>
+                <span className="hidden sm:inline font-medium">スリープ防止</span>
               </span>
-            </button>
+              <div
+                onClick={toggleWakeLock}
+                className={`flex items-center rounded-full p-0.5 w-11 relative cursor-pointer transition-all duration-150 ${
+                  wakeLockActive
+                    ? 'bg-[#85B0B7] hover:bg-[#6B9CA5]'
+                    : 'bg-slate-200 hover:bg-slate-300'
+                }`}
+                title={wakeLockActive ? 'スリープ防止を無効にする' : 'スリープ防止を有効にする'}
+              >
+                <div className={`w-5 h-5 bg-white rounded-full shadow-sm transition-transform duration-200 ${
+                  wakeLockActive ? 'translate-x-5' : 'translate-x-0'
+                }`}></div>
+              </div>
+            </div>
           )}
         </div>
       </div>

--- a/src/layouts/__tests__/Header.test.tsx
+++ b/src/layouts/__tests__/Header.test.tsx
@@ -116,7 +116,7 @@ describe('Header', () => {
     
     const wakeLockButton = screen.getByTitle('スリープ防止を有効にする');
     expect(wakeLockButton).toBeInTheDocument();
-    expect(screen.getByText('スリープ防止')).toBeInTheDocument();
+    expect(screen.getByText('Zzz')).toBeInTheDocument();
   });
 
   it('should call toggleWakeLock when wake lock button is clicked', async () => {
@@ -140,8 +140,8 @@ describe('Header', () => {
       
       // 非アクティブ状態のスタイル確認（デフォルトのモック状態）
       const wakeLockButton = screen.getByTitle('スリープ防止を有効にする');
-      expect(wakeLockButton).toHaveClass('bg-slate-100', 'text-slate-600');
-      expect(screen.getByText('スリープ防止')).toBeInTheDocument();
+      expect(wakeLockButton).toHaveClass('bg-slate-200');
+      expect(screen.getByText('Zzz')).toBeInTheDocument();
     });
 
     it('should handle wake lock button interactions', async () => {
@@ -168,7 +168,7 @@ describe('Header', () => {
       
       // デフォルトのモックではサポートされている
       expect(screen.getByTitle('スリープ防止を有効にする')).toBeInTheDocument();
-      expect(screen.getByText('スリープ防止')).toBeInTheDocument();
+      expect(screen.getByText('Zzz')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- スリープ防止ボタンのUIを太陽/月アイコンから直感的なトグルスイッチに変更
- 斜線付きZzzラベルで機能が一目で理解できるよう改善
- レスポンシブ対応（モバイル: Zzz、デスクトップ: Zzz スリープ防止）

## Test plan
- [x] 全テストが通ることを確認
- [x] Header コンポーネントのテストを新しいUI構造に合わせて更新
- [x] トグルスイッチが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)