### PR TITLE
メモの有無に関わらずコード名の縦位置を統一

### DIFF
--- a/src/components/ChordGridRenderer.tsx
+++ b/src/components/ChordGridRenderer.tsx
@@ -133,7 +133,7 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({
                       <div className="absolute left-0 top-2 bottom-2 w-0.5 bg-slate-600"></div>
                     )}
                     
-                    <div className="px-0.5 py-0.5 h-full flex items-center">
+                    <div className="px-0.5 pt-2.5 pb-0.5 h-full flex items-start">
                       {(() => {
                         // 小節の実際の幅を取得（動的幅計算の結果）
                         const barWidthPx = useDynamicWidth ? getBarWidth(bar, beatsPerBar) : 200; // フォールバック値
@@ -154,7 +154,7 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({
                           return (
                             <div 
                               key={chordIndex} 
-                              className="flex flex-col justify-center hover:bg-slate-100 cursor-pointer rounded px-0.5 flex-shrink-0"
+                              className="flex flex-col justify-start hover:bg-slate-100 cursor-pointer rounded px-0.5 flex-shrink-0"
                               style={{ 
                                 width: `${chordWidthPx}px`,
                                 minWidth: `${CHORD_WIDTH_CONFIG.MIN_WIDTH_PX}px`


### PR DESCRIPTION
## Summary
- メモ機能使用時にコード名の縦位置がズレる問題を修正
- メモがあるコードとないコードで表示位置を統一
- 小節線との位置関係も適切に調整

## 変更内容
- 小節レベルで`items-center`を`items-start`に変更してコード全体を上揃えに統一
- 各コード内で`justify-center`を`justify-start`に変更してメモ位置を統一
- コード表示エリアに`pt-2.5`を追加して小節線との位置関係を調整

## Test plan
- [x] 全ユニットテストが通ることを確認
- [x] リント・ビルドが通ることを確認  
- [x] メモありコードとメモなしコードの縦位置が揃うことを確認
- [x] 小節線からはみ出さないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)