### PR TITLE
fix: コード表示の上下位置とレイアウト間隔を改善

### DIFF
--- a/src/components/ChordChartViewer.tsx
+++ b/src/components/ChordChartViewer.tsx
@@ -37,7 +37,7 @@ const ChordChartViewer: React.FC<ChordChartViewerProps> = ({ chart, currentChart
         <div className="bg-slate-50 rounded-lg p-1" data-testid="chart-content">
           {chart.sections && chart.sections.length > 0 ? (
             chart.sections.map((section) => (
-              <div key={section.id} className="mb-3 last:mb-0" data-testid={`section-${section.id}`}>
+              <div key={section.id} className="mb-1 last:mb-0" data-testid={`section-${section.id}`}>
                 {section.name && (
                   <h3 className="text-xs font-medium text-slate-600 mb-0.5" data-testid={`section-name-${section.id}`}>
                     【{section.name}】

--- a/src/components/ChordGridRenderer.tsx
+++ b/src/components/ChordGridRenderer.tsx
@@ -112,6 +112,9 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({
           <div className="relative bg-white">
             <div className="flex min-h-8 py-0">
               {rowBars.map((bar, barIndex) => {
+                // この行にメモがあるかどうかをチェック
+                const hasAnyMemoInRow = rowBars.some(b => b.some(chord => chord.memo));
+                
                 // 各コードの必要幅を先に計算（コードファースト方式）
                 const chordWidthsPx = useDynamicWidth ? bar.map(chord => {
                   const chordDuration = chord.duration || 4;
@@ -149,10 +152,10 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({
                     }}
                   >
                     {barIndex > 0 && (
-                      <div className="absolute left-0 top-2 bottom-2 w-0.5 bg-slate-600"></div>
+                      <div className="absolute left-0 top-1 bottom-1 w-0.5 bg-slate-600"></div>
                     )}
                     
-                    <div className="px-0.5 py-0.5 h-full flex items-center">
+                    <div className="px-0.5 py-0.5 h-full flex items-stretch" style={{ minHeight: '36px' }}>
                       {bar.map((chord, chordIndex) => {
                         // 動的幅計算の場合は外側で計算済みの幅を使用、従来の場合は基本幅
                         const chordWidthPx = useDynamicWidth && chordWidthsPx 
@@ -162,13 +165,13 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({
                         return (
                           <div 
                             key={chordIndex} 
-                            className="flex flex-col justify-center hover:bg-slate-100 cursor-pointer rounded px-0.5 flex-shrink-0"
+                            className={`flex flex-col hover:bg-slate-100 cursor-pointer rounded px-0.5 flex-shrink-0 h-full ${chord.memo ? 'justify-center' : hasAnyMemoInRow ? 'justify-start pt-1' : 'justify-center'}`}
                             style={{ 
                               width: `${chordWidthPx}px`,
                               minWidth: `${chordWidthPx}px`
                             }}
                           >
-                            <div className="text-left flex items-center">
+                            <div className={`text-left flex items-center ${chord.memo ? 'flex-1' : hasAnyMemoInRow ? '' : 'flex-1'}`}>
                               <span className="text-xs font-medium leading-none">
                                 {(() => {
                                   // コード名をルート音とクオリティに分ける
@@ -192,7 +195,7 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({
                               </span>
                             </div>
                             {chord.memo && (
-                              <div className="text-left text-[10px] text-slate-600 leading-tight">
+                              <div className="text-left text-[10px] text-slate-600 leading-tight px-0.5 pb-1">
                                 {chord.memo}
                               </div>
                             )}
@@ -202,14 +205,14 @@ const ChordGridRenderer: React.FC<ChordGridRendererProps> = ({
                     </div>
                     
                     {barIndex === rowBars.length - 1 && (
-                      <div className="absolute right-0 top-2 bottom-2 w-0.5 bg-slate-600"></div>
+                      <div className="absolute right-0 top-1 bottom-1 w-0.5 bg-slate-600"></div>
                     )}
                   </div>
                 );
               })}
             </div>
             
-            <div className="absolute left-0 top-2 bottom-2 w-0.5 bg-slate-600"></div>
+            <div className="absolute left-0 top-1 bottom-1 w-0.5 bg-slate-600"></div>
           </div>
         </div>
       ))}


### PR DESCRIPTION
## Summary

- メモの有無によるコード位置のズレを解消
- セクション間とセクション内改行の間隔を詰めて密度の高いレイアウトに調整  
- 小節線の長さを調整して行間との適切なバランスを確保

## 修正内容

### コード位置の統一
- **行内全体でメモがない場合**: コード名を中央配置で自然な見た目に
- **メモが混在する場合**: メモがないコードは上寄せ、メモがあるコードは中央配置で位置を統一

### レイアウト間隔の最適化
- **セクション間マージン**: `mb-3` → `mb-1` に変更してセクション間を詰める
- **小節の高さ**: `48px` → `36px` に縮小して行間を詰める
- **小節線の調整**: `top-2 bottom-2` → `top-1 bottom-1` で行間に微妙な隙間を確保

### 技術的実装
- 行レベルでのメモ存在チェック機能を追加
- 条件分岐による適応的なレイアウト制御
- Flexboxレイアウトの最適化

## Test plan

- [x] 既存テストの実行（全て通過）
- [x] ESLintチェック（エラーなし）
- [x] ビルド確認（成功）
- [x] メモありなしの混在パターンでの表示確認
- [x] セクション間隔とレイアウト密度の確認

🤖 Generated with [Claude Code](https://claude.ai/code)