### PR TITLE
feat: ヘッダーとタイトル情報のレイアウトをコンパクト化

### DIFF
--- a/src/components/ChordChartViewer.tsx
+++ b/src/components/ChordChartViewer.tsx
@@ -15,16 +15,18 @@ const ChordChartViewer: React.FC<ChordChartViewerProps> = ({ chart, currentChart
   return (
     <div className="h-full bg-white overflow-y-auto" data-testid="chart-viewer">
       <div className="p-2">
-        <div className="mb-3">
-          <h2 className="text-xl font-bold text-slate-900 mb-1" data-testid="chart-title">{chart.title}</h2>
-          <div className="flex flex-wrap gap-3 text-sm text-slate-600">
-            <span data-testid="chart-artist">{chart.artist}</span>
-            <span data-testid="chart-key">キー: {KEY_DISPLAY_NAMES[chart.key] || chart.key}</span>
-            {chart.tempo && <BpmIndicator bpm={chart.tempo} />}
-            <span data-testid="chart-time-signature">拍子: {chart.timeSignature}</span>
+        <div className="mb-2">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3 flex-wrap">
+            <h2 className="text-lg font-bold text-slate-900" data-testid="chart-title">{chart.title}</h2>
+            <span className="text-sm text-slate-600" data-testid="chart-artist">{chart.artist}</span>
+            <div className="flex flex-wrap gap-3 text-sm text-slate-600">
+              <span data-testid="chart-key">キー: {KEY_DISPLAY_NAMES[chart.key] || chart.key}</span>
+              {chart.tempo && <BpmIndicator bpm={chart.tempo} />}
+              <span data-testid="chart-time-signature">拍子: {chart.timeSignature}</span>
+            </div>
           </div>
           {chart.tags && chart.tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 mt-2" data-testid="chart-tags">
+            <div className="flex flex-wrap gap-2 mt-1" data-testid="chart-tags">
               {chart.tags.map((tag, index) => (
                 <span key={index} className="px-2 py-1 bg-slate-100 text-slate-800 text-xs rounded-full">
                   {tag}

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -19,17 +19,17 @@ const Header: React.FC<HeaderProps> = ({ explorerOpen, setExplorerOpen }) => {
   return (
     <header className="bg-white shadow-sm border-b border-slate-200" data-testid="header">
       <div className="px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center h-16">
+        <div className="flex items-center h-12">
           <button
             onClick={() => setExplorerOpen(!explorerOpen)}
-            className="px-3 py-2 rounded-md bg-slate-100 border border-slate-300 text-slate-600 hover:bg-slate-200 hover:text-slate-700 hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 mr-3 shadow-sm transition-all duration-150 text-sm font-medium"
+            className="px-2 py-1 rounded-md bg-slate-100 border border-slate-300 text-slate-600 hover:bg-slate-200 hover:text-slate-700 hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 mr-3 shadow-sm transition-all duration-150 text-sm font-medium"
             aria-label={explorerOpen ? "Close Score Explorer" : "Open Score Explorer"}
             data-testid="explorer-toggle"
           >
             {explorerOpen ? (
-              <span className="text-lg font-bold">&lt;</span>
+              <span className="text-sm font-bold">&lt;</span>
             ) : (
-              <span className="text-lg font-bold">&gt;</span>
+              <span className="text-sm font-bold">&gt;</span>
             )}
           </button>
           <h1 className="text-xl font-semibold text-slate-900 hidden" data-testid="app-title">Nekogata Score Manager</h1>


### PR DESCRIPTION
## Summary
- ヘッダー高さを縮小（h-16 → h-12）して縦スペース節約
- Score Explorer開閉ボタンの大きさ調整（パディング・フォントサイズ）
- 楽譜タイトル情報を左寄せ横並び配置に変更
- 一画面により多くの楽譜情報を表示可能

## Test plan
- [x] テスト実行確認
- [x] ビルド確認
- [x] Lint確認
- [ ] 視覚的なレイアウト確認（モバイル・デスクトップ）
- [ ] Score Explorer開閉動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)