### PR TITLE
feat: タグ機能の完全削除

### DIFF
--- a/e2e/pages/ChartViewPage.ts
+++ b/e2e/pages/ChartViewPage.ts
@@ -7,7 +7,6 @@ export class ChartViewPage {
   readonly chartArtist: Locator;
   readonly chartKey: Locator;
   readonly chartTimeSignature: Locator;
-  readonly chartTags: Locator;
   readonly chartContent: Locator;
   readonly chartNotes: Locator;
   readonly chartActions: Locator;
@@ -21,7 +20,6 @@ export class ChartViewPage {
     this.chartArtist = page.getByTestId('chart-artist');
     this.chartKey = page.getByTestId('chart-key');
     this.chartTimeSignature = page.getByTestId('chart-time-signature');
-    this.chartTags = page.getByTestId('chart-tags');
     this.chartContent = page.getByTestId('chart-content');
     this.chartNotes = page.getByTestId('chart-notes');
     this.chartActions = page.getByTestId('chart-actions');

--- a/e2e/pages/ChordChartFormPage.ts
+++ b/e2e/pages/ChordChartFormPage.ts
@@ -8,7 +8,6 @@ export class ChordChartFormPage {
   readonly keySelect: Locator;
   readonly tempoInput: Locator;
   readonly timeSignatureSelect: Locator;
-  readonly tagsInput: Locator;
   readonly notesTextarea: Locator;
   readonly cancelButton: Locator;
   readonly saveButton: Locator;
@@ -21,7 +20,6 @@ export class ChordChartFormPage {
     this.keySelect = page.locator('#key');
     this.tempoInput = page.locator('#tempo');
     this.timeSignatureSelect = page.locator('#timeSignature');
-    this.tagsInput = page.locator('#tags');
     this.notesTextarea = page.locator('#notes');
     this.cancelButton = page.getByTestId('cancel-button');
     this.saveButton = page.getByTestId('save-button');
@@ -50,10 +48,6 @@ export class ChordChartFormPage {
     await this.timeSignatureSelect.selectOption(timeSignature);
   }
 
-  async fillTags(tags: string) {
-    await this.tagsInput.clear();
-    await this.tagsInput.fill(tags);
-  }
 
   async fillNotes(notes: string) {
     await this.notesTextarea.clear();
@@ -74,7 +68,6 @@ export class ChordChartFormPage {
     key?: string;
     tempo?: number;
     timeSignature?: string;
-    tags?: string;
     notes?: string;
   }) {
     if (data.title !== undefined) await this.fillTitle(data.title);
@@ -82,7 +75,6 @@ export class ChordChartFormPage {
     if (data.key !== undefined) await this.selectKey(data.key);
     if (data.tempo !== undefined) await this.fillTempo(data.tempo);
     if (data.timeSignature !== undefined) await this.selectTimeSignature(data.timeSignature);
-    if (data.tags !== undefined) await this.fillTags(data.tags);
     if (data.notes !== undefined) await this.fillNotes(data.notes);
   }
 

--- a/e2e/tests/chart-management.spec.ts
+++ b/e2e/tests/chart-management.spec.ts
@@ -103,7 +103,6 @@ test.describe('Nekogata Score Manager - チャート管理機能テスト', () =
     await chartFormPage.fillBasicInfo({
       title: '情報表示テスト',
       artist: 'テストアーティスト',
-      tags: 'テスト, 表示'
     });
     await chartFormPage.clickSave();
     
@@ -113,10 +112,6 @@ test.describe('Nekogata Score Manager - チャート管理機能テスト', () =
     await expect(chartViewPage.chartTitle).toContainText('情報表示テスト');
     await expect(chartViewPage.chartArtist).toContainText('テストアーティスト');
     
-    // タグが正しく表示されていることを確認
-    const tagsSection = page.locator('[data-testid="chart-tags"]');
-    await expect(tagsSection).toContainText('テスト');
-    await expect(tagsSection).toContainText('表示');
   });
 
   test('チャート情報の編集と更新が正しく反映される', async ({ page }) => {

--- a/e2e/tests/comprehensive-chart-flow.spec.ts
+++ b/e2e/tests/comprehensive-chart-flow.spec.ts
@@ -24,7 +24,6 @@ test.describe('Nekogata Score Manager - 包括的なチャート作成フロー'
       key: 'G',
       tempo: 140,
       timeSignature: '3/4',
-      tags: 'ロック, アップテンポ',
       notes: 'イントロはアルペジオで開始'
     });
     
@@ -86,8 +85,6 @@ test.describe('Nekogata Score Manager - 包括的なチャート作成フロー'
     await chartFormPage.selectTimeSignature('6/8');
     await expect(chartFormPage.timeSignatureSelect).toHaveValue('6/8');
     
-    await chartFormPage.fillTags('テスト, ジャンル');
-    await expect(chartFormPage.tagsInput).toHaveValue('テスト, ジャンル');
     
     await chartFormPage.fillNotes('テスト用のメモです');
     await expect(chartFormPage.notesTextarea).toHaveValue('テスト用のメモです');

--- a/e2e/tests/core-functionality.spec.ts
+++ b/e2e/tests/core-functionality.spec.ts
@@ -23,7 +23,6 @@ test.describe('Nekogata Score Manager - コア機能テスト', () => {
       key: 'D',
       tempo: 120,
       timeSignature: '4/4',
-      tags: 'テスト',
       notes: 'コア機能のテストです'
     });
     await chartFormPage.clickSave();

--- a/src/components/ChordChartForm.tsx
+++ b/src/components/ChordChartForm.tsx
@@ -21,7 +21,6 @@ const ChordChartForm: React.FC<ChordChartFormProps> = ({
     key: initialData?.key || 'C',
     tempo: initialData?.tempo || 120,
     timeSignature: initialData?.timeSignature || '4/4',
-    tags: initialData?.tags?.join(', ') || '',
     notes: initialData?.notes || ''
   });
 
@@ -32,7 +31,6 @@ const ChordChartForm: React.FC<ChordChartFormProps> = ({
     
     const chartData = {
       ...formData,
-      tags: formData.tags.split(',').map(tag => tag.trim()).filter(tag => tag.length > 0),
       sections: initialData?.sections
     };
 
@@ -155,19 +153,6 @@ const ChordChartForm: React.FC<ChordChartFormProps> = ({
               </select>
             </div>
 
-            <div>
-              <label htmlFor="tags" className="block text-sm font-medium text-slate-700 mb-2">
-                タグ (カンマ区切り)
-              </label>
-              <input
-                id="tags"
-                type="text"
-                value={formData.tags}
-                onChange={(e) => handleChange('tags', e.target.value)}
-                className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#85B0B7]"
-                placeholder="例: ポップス, バラード"
-              />
-            </div>
           </div>
 
           {/* メモ */}

--- a/src/components/ChordChartViewer.tsx
+++ b/src/components/ChordChartViewer.tsx
@@ -24,15 +24,6 @@ const ChordChartViewer: React.FC<ChordChartViewerProps> = ({ chart }) => {
               <span data-testid="chart-time-signature">拍子: {chart.timeSignature}</span>
             </div>
           </div>
-          {chart.tags && chart.tags.length > 0 && (
-            <div className="flex flex-wrap gap-2 mt-1" data-testid="chart-tags">
-              {chart.tags.map((tag, index) => (
-                <span key={index} className="px-2 py-1 bg-slate-100 text-slate-800 text-xs rounded-full">
-                  {tag}
-                </span>
-              ))}
-            </div>
-          )}
         </div>
 
         <div className="bg-slate-50 rounded-lg p-1" data-testid="chart-content">

--- a/src/components/__tests__/BasicInfoEditor.test.tsx
+++ b/src/components/__tests__/BasicInfoEditor.test.tsx
@@ -13,7 +13,6 @@ const sampleChart: ChordChart = {
   sections: [],
   createdAt: new Date(),
   updatedAt: new Date(),
-  tags: ['test'],
 };
 
 describe('BasicInfoEditor', () => {

--- a/src/components/__tests__/ChordChartForm.test.tsx
+++ b/src/components/__tests__/ChordChartForm.test.tsx
@@ -38,7 +38,6 @@ describe('ChordChartForm', () => {
       expect(screen.getByLabelText('キー *')).toBeInTheDocument();
       expect(screen.getByLabelText('テンポ (BPM)')).toBeInTheDocument();
       expect(screen.getByLabelText('拍子 *')).toBeInTheDocument();
-      expect(screen.getByLabelText('タグ (カンマ区切り)')).toBeInTheDocument();
       expect(screen.getByLabelText('メモ')).toBeInTheDocument();
     });
 
@@ -61,7 +60,6 @@ describe('ChordChartForm', () => {
         key: 'G',
         tempo: 140,
         timeSignature: '3/4',
-        tags: ['rock', 'classic'],
         notes: 'Some notes'
       };
 
@@ -75,7 +73,6 @@ describe('ChordChartForm', () => {
       expect(keySelect.value).toBe('G');
       expect(screen.getByDisplayValue('140')).toBeInTheDocument();
       expect(screen.getByDisplayValue('3/4')).toBeInTheDocument();
-      expect(screen.getByDisplayValue('rock, classic')).toBeInTheDocument();
       expect(screen.getByDisplayValue('Some notes')).toBeInTheDocument();
     });
   });
@@ -167,7 +164,6 @@ describe('ChordChartForm', () => {
       await user.selectOptions(screen.getByLabelText('キー *'), 'G');
       // Use fireEvent for number input to avoid concatenation issues
       fireEvent.change(screen.getByLabelText('テンポ (BPM)'), { target: { value: '140' } });
-      await user.type(screen.getByLabelText('タグ (カンマ区切り)'), 'rock, test');
       await user.type(screen.getByLabelText('メモ'), 'Test notes');
 
       await user.click(screen.getByText('作成'));
@@ -181,27 +177,12 @@ describe('ChordChartForm', () => {
       expect(savedChart.artist).toBe('Test Artist');
       expect(savedChart.key).toBe('G');
       expect(savedChart.tempo).toBe(140);
-      expect(savedChart.tags).toEqual(['rock', 'test']);
       expect(savedChart.notes).toBe('Test notes');
       expect(savedChart.id).toBeDefined();
       expect(savedChart.createdAt).toBeInstanceOf(Date);
       expect(savedChart.updatedAt).toBeInstanceOf(Date);
     });
 
-    it('should handle tag parsing correctly', async () => {
-      const user = userEvent.setup();
-      renderForm();
-
-      await user.type(screen.getByLabelText('タグ (カンマ区切り)'), 'rock, pop , jazz,  , electronic');
-      await user.click(screen.getByText('作成'));
-
-      await waitFor(() => {
-        expect(mockOnSave).toHaveBeenCalledTimes(1);
-      });
-
-      const savedChart = mockOnSave.mock.calls[0][0];
-      expect(savedChart.tags).toEqual(['rock', 'pop', 'jazz', 'electronic']);
-    });
   });
 
   describe('Cancel Functionality', () => {
@@ -234,7 +215,7 @@ describe('ChordChartForm', () => {
       renderForm();
 
       expect(screen.getByRole('form')).toBeInTheDocument();
-      expect(screen.getAllByRole('textbox')).toHaveLength(4); // title, artist, tags, notes
+      expect(screen.getAllByRole('textbox')).toHaveLength(3); // title, artist, notes
       expect(screen.getAllByRole('spinbutton')).toHaveLength(1); // tempo
       expect(screen.getAllByRole('combobox')).toHaveLength(2); // key, timeSignature
       expect(screen.getAllByRole('button')).toHaveLength(2); // cancel, submit

--- a/src/components/__tests__/ChordChartViewer.test.tsx
+++ b/src/components/__tests__/ChordChartViewer.test.tsx
@@ -45,7 +45,6 @@ describe('ChordChartViewer', () => {
     ],
     createdAt: new Date('2024-01-01'),
     updatedAt: new Date('2024-01-01'),
-    tags: ['pop', 'test'],
     notes: 'Test notes for this chart'
   };
 
@@ -62,12 +61,6 @@ describe('ChordChartViewer', () => {
       expect(screen.getByText('拍子: 4/4')).toBeInTheDocument();
     });
 
-    it('should render tags correctly', () => {
-      render(<ChordChartViewer chart={mockChartData} currentChartId="test-chart-1" onEdit={mockOnEdit} />);
-
-      expect(screen.getByText('pop')).toBeInTheDocument();
-      expect(screen.getByText('test')).toBeInTheDocument();
-    });
 
     it('should render notes section when notes exist', () => {
       render(<ChordChartViewer chart={mockChartData} currentChartId="test-chart-1" onEdit={mockOnEdit} />);
@@ -83,21 +76,7 @@ describe('ChordChartViewer', () => {
       expect(screen.queryByText('メモ')).not.toBeInTheDocument();
     });
 
-    it('should not render tags section when tags are empty', () => {
-      const chartWithoutTags = { ...mockChartData, tags: [] };
-      render(<ChordChartViewer chart={chartWithoutTags} currentChartId="test-chart-1" onEdit={mockOnEdit} />);
 
-      expect(screen.queryByText('pop')).not.toBeInTheDocument();
-      expect(screen.queryByText('test')).not.toBeInTheDocument();
-    });
-
-    it('should not render tags section when tags are undefined', () => {
-      const chartWithoutTags = { ...mockChartData, tags: undefined };
-      render(<ChordChartViewer chart={chartWithoutTags} currentChartId="test-chart-1" onEdit={mockOnEdit} />);
-
-      expect(screen.queryByText('pop')).not.toBeInTheDocument();
-      expect(screen.queryByText('test')).not.toBeInTheDocument();
-    });
 
     it('should handle missing optional fields gracefully', () => {
       const minimalChart: ChordChartType = {

--- a/src/components/__tests__/ChordSelection.test.tsx
+++ b/src/components/__tests__/ChordSelection.test.tsx
@@ -72,7 +72,6 @@ const sampleChart: ChordChart = {
   ],
   createdAt: new Date(),
   updatedAt: new Date(),
-  tags: ['test'],
 };
 
 describe('ChordSelection', () => {

--- a/src/layouts/ScoreExplorer.tsx
+++ b/src/layouts/ScoreExplorer.tsx
@@ -104,15 +104,6 @@ const ScoreExplorer: React.FC<ScoreExplorerProps> = ({
                 <div className="flex-1">
                   <h3 className="text-sm font-medium text-slate-900">{chart.title}</h3>
                   <p className="text-xs text-slate-500 mt-1">{chart.artist}</p>
-                  {chart.tags && chart.tags.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-2">
-                      {chart.tags.slice(0, 2).map((tag, index) => (
-                        <span key={index} className="px-1.5 py-0.5 bg-[#BDD0CA] text-slate-800 text-xs rounded">
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  )}
                 </div>
                 <button
                   onClick={(e) => {

--- a/src/layouts/__tests__/MainLayout.test.tsx
+++ b/src/layouts/__tests__/MainLayout.test.tsx
@@ -21,7 +21,6 @@ vi.mock('../../hooks/useChartManagement', () => ({
           timeSignature: '4/4',
           sections: [],
           notes: '',
-          tags: [],
           createdAt: new Date('2023-01-01T00:00:00.000Z'),
           updatedAt: new Date('2023-01-01T00:00:00.000Z'),
         },

--- a/src/layouts/__tests__/ScoreExplorer.test.tsx
+++ b/src/layouts/__tests__/ScoreExplorer.test.tsx
@@ -13,7 +13,6 @@ const mockCharts: ChordChart[] = [
     timeSignature: '4/4',
     sections: [],
     notes: '',
-    tags: ['tag1', 'tag2'],
     createdAt: new Date('2023-01-01T00:00:00.000Z'),
     updatedAt: new Date('2023-01-01T00:00:00.000Z'),
   },
@@ -26,7 +25,6 @@ const mockCharts: ChordChart[] = [
     timeSignature: '4/4',
     sections: [],
     notes: '',
-    tags: [],
     createdAt: new Date('2023-01-02T00:00:00.000Z'),
     updatedAt: new Date('2023-01-02T00:00:00.000Z'),
   },
@@ -293,27 +291,6 @@ describe('ScoreExplorer', () => {
     expect(screen.getByText('1件選択中')).toBeInTheDocument();
   });
 
-  it('should render tags when available', () => {
-    render(
-      <ScoreExplorer
-        charts={mockCharts}
-        currentChartId={null}
-        selectedChartIds={[]}
-        onChartSelect={mockOnChartSelect}
-        onSelectAll={mockOnSelectAll}
-        onSetCurrentChart={mockOnSetCurrentChart}
-        onCreateNew={mockOnCreateNew}
-        onImport={mockOnImport}
-        onExportSelected={mockOnExportSelected}
-        onDeleteSelected={mockOnDeleteSelected}
-        onDuplicateSelected={mockOnDuplicateSelected}
-        onEditChart={mockOnEditChart}
-      />
-    );
-
-    expect(screen.getByText('tag1')).toBeInTheDocument();
-    expect(screen.getByText('tag2')).toBeInTheDocument();
-  });
 
   describe('Complex Selection Behaviors', () => {
     it('should show correct bulk select checkbox states', () => {
@@ -513,7 +490,6 @@ describe('ScoreExplorer', () => {
           ...mockCharts[0],
           title: 'Very Long Chart Title That Might Overflow The Container Width',
           artist: 'Artist With Very Long Name That Also Might Cause Layout Issues',
-          tags: ['tag1', 'tag2', 'tag3', 'tag4', 'tag5', 'tag6'],
         }
       ];
 
@@ -536,10 +512,9 @@ describe('ScoreExplorer', () => {
       expect(screen.getByText('Very Long Chart Title That Might Overflow The Container Width')).toBeInTheDocument();
       expect(screen.getByText('Artist With Very Long Name That Also Might Cause Layout Issues')).toBeInTheDocument();
       
-      // 最初の2つのタグのみ表示される（slice(0, 2)の実装による）
-      expect(screen.getByText('tag1')).toBeInTheDocument();
-      expect(screen.getByText('tag2')).toBeInTheDocument();
-      expect(screen.queryByText('tag3')).not.toBeInTheDocument();
+      // タグは表示されないため、タイトルとアーティストのみ確認
+      expect(screen.getByText('Very Long Chart Title That Might Overflow The Container Width')).toBeInTheDocument();
+      expect(screen.getByText('Artist With Very Long Name That Also Might Cause Layout Issues')).toBeInTheDocument();
     });
   });
 

--- a/src/stores/__tests__/syncStore.test.ts
+++ b/src/stores/__tests__/syncStore.test.ts
@@ -233,7 +233,6 @@ describe('syncStore', () => {
         key: 'C',
         timeSignature: '4/4',
         sections: [],
-        tags: [],
         notes: '',
         createdAt: new Date(),
         updatedAt: new Date()
@@ -245,7 +244,6 @@ describe('syncStore', () => {
         key: 'G',
         timeSignature: '4/4',
         sections: [],
-        tags: [],
         notes: '',
         createdAt: new Date(),
         updatedAt: new Date()

--- a/src/types/chord.ts
+++ b/src/types/chord.ts
@@ -25,7 +25,6 @@ export interface ChordChart {
   sections: ChordSection[];
   createdAt: Date;
   updatedAt: Date;
-  tags?: string[];
   notes?: string;
   version?: string;
 }

--- a/src/utils/__tests__/chartMigration.test.ts
+++ b/src/utils/__tests__/chartMigration.test.ts
@@ -23,7 +23,6 @@ describe('chartMigration', () => {
     ],
     createdAt: new Date('2023-01-01'),
     updatedAt: new Date('2023-01-01'),
-    tags: ['test'],
     notes: undefined as unknown as string, // 古いデータではnotesが未定義
     version
   });
@@ -41,7 +40,7 @@ describe('chartMigration', () => {
       
       // v2マイグレーション: memo追加
       expect(result.sections[0].chords[0].memo).toBe('');
-      expect(result.version).toBe('2.0.0');
+      expect(result.version).toBe('3.0.0');
     });
 
     it('version 0.x.xの場合、v1とv2両方のマイグレーションを実行', () => {
@@ -53,7 +52,7 @@ describe('chartMigration', () => {
       expect(result.sections[0].beatsPerBar).toBe(3);
       expect(result.notes).toBe('');
       expect(result.sections[0].chords[0].memo).toBe('');
-      expect(result.version).toBe('2.0.0');
+      expect(result.version).toBe('3.0.0');
     });
 
     it('version 1.x.xの場合、v2マイグレーションのみ実行', () => {
@@ -67,7 +66,7 @@ describe('chartMigration', () => {
       
       // v2マイグレーション: memo追加
       expect(result.sections[0].chords[0].memo).toBe('');
-      expect(result.version).toBe('2.0.0');
+      expect(result.version).toBe('3.0.0');
     });
 
     it('version 2.x.xの場合、マイグレーション不要', () => {
@@ -78,7 +77,7 @@ describe('chartMigration', () => {
       // 何も変更されない
       expect(result.sections[0].beatsPerBar).toBe(4);
       expect(result.sections[0].chords[0].memo).toBe('');
-      expect(result.version).toBe('2.0.0');
+      expect(result.version).toBe('3.0.0');
     });
   });
 
@@ -156,7 +155,7 @@ describe('chartMigration', () => {
       
       const result = migrateChartData(chart);
       
-      expect(result.version).toBe('2.0.0');
+      expect(result.version).toBe('3.0.0');
     });
   });
 

--- a/src/utils/__tests__/chordUtils.test.ts
+++ b/src/utils/__tests__/chordUtils.test.ts
@@ -17,7 +17,6 @@ describe('chordUtils', () => {
       expect(chart.timeSignature).toBe('4/4');
       expect(chart.sections).toHaveLength(1);
       expect(chart.sections[0].name).toBe('イントロ');
-      expect(chart.tags).toEqual([]);
       expect(chart.notes).toBe('');
     });
 

--- a/src/utils/__tests__/export.test.ts
+++ b/src/utils/__tests__/export.test.ts
@@ -63,7 +63,6 @@ const mockChart: ChordChart = {
   ],
   createdAt: new Date('2023-01-01'),
   updatedAt: new Date('2023-01-01'),
-  tags: ['test'],
   notes: 'テストメモ'
 };
 

--- a/src/utils/__tests__/import.test.ts
+++ b/src/utils/__tests__/import.test.ts
@@ -25,7 +25,6 @@ const mockChart: ChordChart = {
   ],
   createdAt: new Date('2023-01-01'),
   updatedAt: new Date('2023-01-01'),
-  tags: ['test'],
   notes: 'テストメモ'
 };
 

--- a/src/utils/__tests__/migration.test.ts
+++ b/src/utils/__tests__/migration.test.ts
@@ -27,7 +27,6 @@ describe('Migration Utils', () => {
     ],
     createdAt: new Date('2023-01-01'),
     updatedAt: new Date('2023-01-01'),
-    tags: ['test'],
     notes: undefined // メモ機能がない
   };
 
@@ -62,7 +61,7 @@ describe('Migration Utils', () => {
       expect(result['test-1']).toBeDefined();
       expect(result['test-1'].sections[0].beatsPerBar).toBe(3); // 3/4拍子に修正
       expect(result['test-1'].notes).toBe(''); // 空文字で初期化
-      expect(result['test-1'].version).toBe('2.0.0'); // 最新version追加
+      expect(result['test-1'].version).toBe('3.0.0'); // 最新version追加
     });
 
     it('旧バージョン情報付きデータを移行', () => {
@@ -76,21 +75,21 @@ describe('Migration Utils', () => {
       expect(result['test-1']).toBeDefined();
       expect(result['test-1'].sections[0].beatsPerBar).toBe(3);
       expect(result['test-1'].notes).toBe('');
-      expect(result['test-1'].version).toBe('2.0.0');
+      expect(result['test-1'].version).toBe('3.0.0');
     });
 
     it('v1データはv2にマイグレーションされる', () => {
       const result = migrateData(mockLibraryWithVersions);
       
-      expect(result['test-1'].version).toBe('2.0.0');
-      expect(result['test-2'].version).toBe('2.0.0');
+      expect(result['test-1'].version).toBe('3.0.0');
+      expect(result['test-2'].version).toBe('3.0.0');
     });
 
     it('v2データはマイグレーション不要', () => {
       const result = migrateData(mockLibraryV2);
       
-      expect(result['test-1'].version).toBe('2.0.0');
-      expect(result['test-2'].version).toBe('2.0.0');
+      expect(result['test-1'].version).toBe('3.0.0');
+      expect(result['test-2'].version).toBe('3.0.0');
     });
 
     it('空データの場合は空オブジェクトを返す', () => {
@@ -169,8 +168,8 @@ describe('Migration Utils', () => {
       expect(Object.keys(result)).toHaveLength(2);
       expect(result.chart1.sections[0].beatsPerBar).toBe(4); // 4/4拍子は4拍のまま
       expect(result.chart2.sections[0].beatsPerBar).toBe(6); // 6/8拍子は6拍に修正
-      expect(result.chart1.version).toBe('2.0.0');
-      expect(result.chart2.version).toBe('2.0.0');
+      expect(result.chart1.version).toBe('3.0.0');
+      expect(result.chart2.version).toBe('3.0.0');
     });
 
     it('エラーのあるデータの処理', () => {

--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -77,7 +77,7 @@ describe('storageService', () => {
       expect(result).toEqual({
         [mockChart.id]: {
           ...mockChart,
-          version: '2.0.0'
+          version: '3.0.0'
         }
       });
     });
@@ -157,7 +157,7 @@ describe('storageService', () => {
           id: 'other-chart',
           sections: [], // マイグレーションで追加される
           notes: '', // マイグレーションで追加される
-          version: '2.0.0' // 最新versionが追加される
+          version: '3.0.0' // 最新versionが追加される
         },
         [mockChart.id]: mockChart
       });
@@ -183,7 +183,7 @@ describe('storageService', () => {
           id: 'other-chart',
           sections: [], // マイグレーションで追加される
           notes: '', // マイグレーションで追加される
-          version: '2.0.0' // 最新versionが追加される
+          version: '3.0.0' // 最新versionが追加される
         }
       });
     });

--- a/src/utils/chartMigration.ts
+++ b/src/utils/chartMigration.ts
@@ -41,6 +41,20 @@ const migrateChartDataV2 = (chart: ChordChart): ChordChart => {
 };
 
 /**
+ * v3.0.0のマイグレーション: tagsフィールド削除
+ */
+const migrateChartDataV3 = (chart: ChordChart): ChordChart => {
+  // tagsフィールドを削除
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { tags, ...chartWithoutTags } = chart as ChordChart & { tags?: string[] };
+  return {
+    ...chartWithoutTags,
+    // version情報を3.0.0に設定
+    version: '3.0.0'
+  };
+};
+
+/**
  * セマンティックバージョンを解析
  */
 const parseVersion = (version: string): { major: number; minor: number; patch: number } => {
@@ -72,6 +86,7 @@ interface Migration {
 const migrations: Migration[] = [
   { version: '1.0.0', migrate: migrateChartDataV1 },
   { version: '2.0.0', migrate: migrateChartDataV2 },
+  { version: '3.0.0', migrate: migrateChartDataV3 },
 ];
 
 /**

--- a/src/utils/chordCreation.ts
+++ b/src/utils/chordCreation.ts
@@ -10,7 +10,6 @@ export const createEmptyChordChart = (): Omit<ChordChart, 'id' | 'createdAt' | '
     tempo: 120,
     timeSignature,
     sections: [createEmptySection('イントロ', timeSignature)],
-    tags: [],
     notes: ''
   };
 };

--- a/src/utils/importFunctions.ts
+++ b/src/utils/importFunctions.ts
@@ -244,7 +244,6 @@ const validateSingleChart = (chart: unknown, exportVersion?: string): {
     createdAt,
     updatedAt: new Date(), // インポート時に更新日時を現在に設定
     sections: validSections as unknown as ChordSection[],
-    tags: Array.isArray(chartObj.tags) ? chartObj.tags as string[] : [],
     notes: typeof chartObj.notes === 'string' ? chartObj.notes : '',
     version: typeof chartObj.version === 'string' ? chartObj.version : exportVersion
   };


### PR DESCRIPTION
## 概要

コード譜のタグ機能は表示のみで実際の機能（フィルタリング、検索等）に使用されていなかったため、コードベースを簡潔にするために完全に削除しました。

## 変更内容

### 🗂️ データ構造
- ChordChart型からtagsフィールドを除去
- v3.0.0マイグレーションを追加（既存データからtagsを自動削除）

### 🎨 UI変更  
- ChordChartViewerからタグ表示を削除
- ScoreExplorerからタグ表示を削除
- ChordChartFormからタグ入力フィールドを削除

### ⚙️ ユーティリティ
- chordCreation.tsからtags初期化処理を削除
- importFunctions.tsからtags処理を削除

### 🧪 テスト
- 全E2Eテスト（5ファイル）からタグ関連コードを削除
- 全ユニットテスト（12ファイル）からタグ関連テストを削除
- マイグレーションテストをv3.0.0に対応

## 📊 統計
- **削除行数**: 150行
- **追加行数**: 35行（マイグレーション処理）
- **変更ファイル**: 25ファイル

## 🔄 マイグレーション
既存ユーザーのデータは起動時に自動的にv3.0.0形式にマイグレーションされ、tagsフィールドが削除されます。

## ✅ 品質確認
- [x] ESLint通過
- [x] TypeScriptビルド成功  
- [x] 全テスト通過（51ファイル、687テスト）

## 📝 影響範囲
- 既存ユーザー: データ自動マイグレーション、UI変更のみ
- 機能的影響: なし（タグは表示専用で未使用機能）
- パフォーマンス: コード量削減によりわずかに向上

🤖 Generated with [Claude Code](https://claude.ai/code)