### PR TITLE
fix: Dropbox認証でリフレッシュトークンがある場合も連携状態を維持するように改善

### DIFF
--- a/src/utils/sync/__tests__/dropboxAdapter.test.ts
+++ b/src/utils/sync/__tests__/dropboxAdapter.test.ts
@@ -20,6 +20,7 @@ describe('DropboxSyncAdapter', () => {
   let mockAuthProvider: {
     initialize: Mock;
     isAuthenticated: Mock;
+    hasValidRefreshToken: Mock;
     authenticate: Mock;
     signOut: Mock;
     getAccessToken: Mock;
@@ -33,6 +34,7 @@ describe('DropboxSyncAdapter', () => {
     mockAuthProvider = {
       initialize: vi.fn().mockResolvedValue(undefined),
       isAuthenticated: vi.fn().mockReturnValue(true),
+      hasValidRefreshToken: vi.fn().mockReturnValue(false),
       authenticate: vi.fn().mockResolvedValue(undefined),
       signOut: vi.fn(),
       getAccessToken: vi.fn().mockReturnValue('mock-access-token'),
@@ -66,10 +68,31 @@ describe('DropboxSyncAdapter', () => {
   });
 
   describe('isAuthenticated', () => {
-    it('should return auth provider authentication status', () => {
+    it('should return true when access token is valid', () => {
+      mockAuthProvider.isAuthenticated.mockReturnValue(true);
+      mockAuthProvider.hasValidRefreshToken.mockReturnValue(false);
+      
       const result = adapter.isAuthenticated();
       expect(result).toBe(true);
       expect(mockAuthProvider.isAuthenticated).toHaveBeenCalled();
+    });
+
+    it('should return true when only refresh token exists', () => {
+      mockAuthProvider.isAuthenticated.mockReturnValue(false);
+      mockAuthProvider.hasValidRefreshToken.mockReturnValue(true);
+      
+      const result = adapter.isAuthenticated();
+      expect(result).toBe(true);
+      expect(mockAuthProvider.isAuthenticated).toHaveBeenCalled();
+      expect(mockAuthProvider.hasValidRefreshToken).toHaveBeenCalled();
+    });
+
+    it('should return false when neither token exists', () => {
+      mockAuthProvider.isAuthenticated.mockReturnValue(false);
+      mockAuthProvider.hasValidRefreshToken.mockReturnValue(false);
+      
+      const result = adapter.isAuthenticated();
+      expect(result).toBe(false);
     });
   });
 

--- a/src/utils/sync/__tests__/dropboxAuth.test.ts
+++ b/src/utils/sync/__tests__/dropboxAuth.test.ts
@@ -135,6 +135,48 @@ describe('DropboxAuthProvider', () => {
     });
   });
 
+  describe('hasValidRefreshToken', () => {
+    it('should return false when no tokens', () => {
+      expect(authProvider.hasValidRefreshToken()).toBe(false);
+    });
+
+    it('should return true when refresh token exists', async () => {
+      const tokenWithRefresh = {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() + 3600000
+      };
+      localStorageMock.setItem('nekogata-dropbox-tokens', JSON.stringify(tokenWithRefresh));
+      await authProvider.initialize();
+      
+      expect(authProvider.hasValidRefreshToken()).toBe(true);
+    });
+
+    it('should return false when no refresh token', async () => {
+      const tokenWithoutRefresh = {
+        accessToken: 'access-token',
+        expiresAt: Date.now() + 3600000
+      };
+      localStorageMock.setItem('nekogata-dropbox-tokens', JSON.stringify(tokenWithoutRefresh));
+      await authProvider.initialize();
+      
+      expect(authProvider.hasValidRefreshToken()).toBe(false);
+    });
+
+    it('should return true even when access token is expired but refresh token exists', async () => {
+      const expiredTokenWithRefresh = {
+        accessToken: 'expired-token',
+        refreshToken: 'refresh-token',
+        expiresAt: Date.now() - 3600000
+      };
+      localStorageMock.setItem('nekogata-dropbox-tokens', JSON.stringify(expiredTokenWithRefresh));
+      await authProvider.initialize();
+      
+      expect(authProvider.hasValidRefreshToken()).toBe(true);
+      expect(authProvider.isAuthenticated()).toBe(false); // アクセストークンは期限切れ
+    });
+  });
+
   describe('authenticate', () => {
     it('should return existing valid token', async () => {
       const validToken = {

--- a/src/utils/sync/dropboxAdapter.ts
+++ b/src/utils/sync/dropboxAdapter.ts
@@ -24,7 +24,8 @@ export class DropboxSyncAdapter implements ISyncAdapter {
   }
   
   isAuthenticated(): boolean {
-    return this.auth.isAuthenticated();
+    // アクセストークンが有効、またはリフレッシュトークンがある場合は認証済みとする
+    return this.auth.isAuthenticated() || this.auth.hasValidRefreshToken();
   }
   
   async authenticate(): Promise<void> {

--- a/src/utils/sync/dropboxAuth.ts
+++ b/src/utils/sync/dropboxAuth.ts
@@ -224,6 +224,10 @@ export class DropboxAuthProvider {
     return !!(this.tokens && this.isTokenValid());
   }
 
+  hasValidRefreshToken(): boolean {
+    return !!(this.tokens?.refreshToken);
+  }
+
   private isTokenValid(): boolean {
     if (!this.tokens) {
       return false;


### PR DESCRIPTION
## Summary
- アクセストークンが期限切れになってもリフレッシュトークンがある場合は「連携中」と表示されるように修正
- 4時間後に未連携になってしまう問題を解決

## 問題の詳細
Dropboxのアクセストークンは4時間で期限切れになりますが、現在の実装では期限切れ時に即座に「未連携」と表示されていました。実際にはリフレッシュトークンがあれば自動的にアクセストークンを更新できるため、これは不適切な表示でした。

## 変更内容
- `dropboxAuth.ts`に`hasValidRefreshToken()`メソッドを追加
- `dropboxAdapter.ts`の`isAuthenticated()`メソッドを改善し、リフレッシュトークンの存在も考慮
- 関連するテストを追加・更新

## Test plan
- [x] 全てのテストが通ることを確認
- [x] Lintエラーがないことを確認
- [x] ビルドが成功することを確認
- [ ] アプリを起動して4時間後も連携状態が維持されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)