### PR TITLE
feat: セットリスト機能の基盤実装（PR1）

### DIFF
--- a/design_docs/setlist-design.md
+++ b/design_docs/setlist-design.md
@@ -1,0 +1,293 @@
+# セットリスト機能設計
+
+## 概要
+
+コード譜管理アプリ「Nekogata Score Manager」にセットリスト機能を追加する。
+既存の楽譜管理機能を拡張し、ライブやセッション用の楽譜セットを作成・管理できるようにする。
+
+## UI設計
+
+### 1. [楽譜]タブ（既存機能拡張）
+
+```
+┌─[楽譜]─[セットリスト]─────────┐
+│ Score Explorer                │
+├─────────────────────────────┤
+│ ☑ 一括選択    ⚙3件選択中    │  ← ActionDropdownに「セットリスト作成」追加
+│                             │
+│ ☑ Song A (Key: C)          │
+│   Artist: John             │
+│ ☑ Song B (Key: G)          │
+│   Artist: Jane             │
+│ ☐ Song C (Key: Am)         │
+│   Artist: Bob              │
+│                             │
+│ [新規作成] [インポート]      │
+└─────────────────────────────┘
+```
+
+**ActionDropdown追加項目**：
+- エクスポート（既存）
+- 削除（既存）
+- 複製（既存）
+- **→ セットリスト作成**（新規）
+
+### 2. [セットリスト]タブ（新規）
+
+```
+┌─[楽譜]─[セットリスト]─────────┐
+│ ▼ Live Set 2024-06      [×] │  ← セットリスト選択+削除
+│   (3曲)                     │
+├─────────────────────────────┤
+│ ⋮⋮ 1. Song D (Key: F)      │  ← D&D取っ手+順序番号
+│      Artist: John          │
+│ ⋮⋮ 2. Song E (Key: C)      │
+│      Artist: Jane          │
+│ ⋮⋮ 3. Song F (Key: G)      │
+│      Artist: Bob           │
+│                             │
+│ ※セットリスト未選択時は     │
+│ 「セットリストを選択して     │
+│  ください」表示             │
+└─────────────────────────────┘
+```
+
+### 3. セットリスト選択ドロップダウン
+
+```
+┌─ セットリスト選択 ────────┐
+│ ✓ Live Set 2024-06  [×] │  ← 現在選択中+削除ボタン
+│   アコースティック   [×] │
+│   練習用セット      [×] │
+│   (セットリストなし)    │  ← 未選択状態
+└─────────────────────────┘
+```
+
+**並び順**: セットリスト名の昇順（日本語・英語混在対応）
+
+### 4. セットリスト作成フロー
+
+1. [楽譜]タブで複数楽譜選択
+2. ActionDropdown → [セットリスト作成]
+3. **インライン入力**：「セットリスト名: [入力フィールド]」
+4. Enter/保存 → セットリスト作成 → [セットリスト]タブに自動切り替え
+
+## データモデル設計
+
+### SetList型定義
+
+```typescript
+interface SetList {
+  id: string;                    // ユニークID（'setlist-' + timestamp + random）
+  name: string;                  // セットリスト名
+  chartIds: string[];            // 楽譜IDの配列（順序を保持）
+  createdAt: Date;               // 作成日時
+}
+
+interface SetListLibrary {
+  [key: string]: SetList;        // SetList.idをキーとした辞書
+}
+```
+
+### 既存型との関係
+
+- `ChordChart`: 既存の楽譜データ型（変更なし）
+- `SetList.chartIds`: `ChordChart.id`の配列として参照関係を構築
+
+## 技術的設計
+
+### 1. Zustandストア設計
+
+```typescript
+// 新規ストア: src/stores/setListStore.ts
+interface SetListState {
+  setLists: SetListLibrary;
+  currentSetListId: string | null;
+  
+  // アクション
+  createSetList: (name: string, chartIds: string[]) => Promise<void>;
+  deleteSetList: (id: string) => Promise<void>;
+  updateSetListOrder: (id: string, newChartIds: string[]) => Promise<void>;
+  setCurrentSetList: (id: string | null) => void;
+  loadFromStorage: () => Promise<void>;
+}
+```
+
+### 2. LocalForage設計
+
+```typescript
+// 保存キー
+const SETLIST_STORAGE_KEY = 'nekogata-setlists';
+
+// 保存データ構造
+interface StoredSetListData {
+  version: string;              // マイグレーション用
+  setLists: SetListLibrary;
+  currentSetListId: string | null;
+}
+```
+
+### 3. Dropbox同期設計
+
+```typescript
+// 同期ファイル名
+const SETLIST_SYNC_FILENAME = 'setlists.json';
+
+// 同期対象データ
+interface SyncSetListData {
+  version: string;
+  setLists: SetListLibrary;
+  syncedAt: string;             // ISO 8601形式
+}
+
+// 同期機能統合
+// 既存のsyncStoreを拡張してセットリストデータも同期対象に含める
+interface SyncState {
+  // 既存のcharts同期機能
+  charts: ChordLibrary;
+  // 新規追加：セットリスト同期機能
+  setLists: SetListLibrary;
+  // ... 他の既存機能
+}
+```
+
+**同期タイミング**：
+- セットリスト作成時
+- セットリスト削除時
+- セットリスト順序変更時
+
+### 4. コンポーネント設計
+
+#### 新規コンポーネント
+
+```
+src/components/
+├── SetListTab.tsx              // セットリストタブのメインコンポーネント
+├── SetListSelector.tsx         // セットリスト選択ドロップダウン
+├── SetListChartItem.tsx        // セットリスト内の楽譜アイテム（D&D対応）
+└── SetListCreationForm.tsx     // セットリスト作成フォーム（インライン）
+```
+
+#### 既存コンポーネント拡張
+
+```
+src/layouts/
+├── ScoreExplorer.tsx           // タブ機能追加
+└── ActionDropdown.tsx          // セットリスト作成アクション追加
+```
+
+## 実装計画
+
+### Phase 1: 基盤実装（Week 1）
+
+1. **データモデル実装**
+   - `src/types/setList.ts`作成
+   - SetList型定義
+
+2. **Zustandストア実装**
+   - `src/stores/setListStore.ts`作成
+   - 基本CRUD操作実装
+
+3. **LocalForage連携**
+   - `src/utils/setListStorage.ts`作成
+   - 永続化機能実装
+
+### Phase 2: UI基礎実装（Week 2）
+
+4. **タブ機能追加**
+   - ScoreExplorerにタブ切り替え機能追加
+   - セットリストタブの基本構造実装
+
+5. **セットリスト選択機能**
+   - SetListSelector.tsxコンポーネント作成
+   - ドロップダウンUI実装（名前昇順ソート）
+
+6. **セットリスト作成機能**
+   - ActionDropdownにセットリスト作成追加
+   - インライン作成フォーム実装
+
+7. **Dropbox同期連携**
+   - 既存syncStoreにセットリスト同期機能追加
+   - セットリストデータの同期タイミング実装
+
+### Phase 3: 高度な機能実装（Week 3）
+
+8. **D&D機能実装**
+   - @dnd-kitによる順序変更機能
+   - SetListChartItem.tsxコンポーネント作成
+
+9. **セットリスト表示機能**
+   - セットリスト内楽譜一覧表示
+   - 楽譜クリック→表示切り替え連携
+
+10. **削除機能実装**
+    - セットリスト削除機能
+    - 確認ダイアログ実装
+
+### Phase 4: 統合・テスト・最適化（Week 4）
+
+11. **テスト実装**
+    - ユニットテスト作成
+    - E2Eテスト追加
+
+12. **モバイル対応**
+    - レスポンシブデザイン調整
+    - モバイルでのD&D操作最適化
+
+13. **パフォーマンス最適化**
+    - 大量セットリスト時の最適化
+    - メモリ使用量最適化
+
+## 操作フロー
+
+### セットリスト作成
+1. [楽譜]タブで楽譜を複数選択
+2. ActionDropdown → [セットリスト作成]
+3. セットリスト名入力
+4. Enter → セットリスト作成完了
+5. [セットリスト]タブに自動切り替え
+
+### セットリスト表示・操作
+1. [セットリスト]タブ選択
+2. ドロップダウンでセットリスト選択
+3. セットリスト内楽譜一覧表示
+4. D&Dで順序変更
+5. 楽譜クリック → メイン表示切り替え
+
+### セットリスト削除
+1. セットリスト選択ドロップダウン展開
+2. 削除したいセットリストの[×]ボタンクリック
+3. 確認ダイアログ → 削除実行
+
+## UI/UXの配慮事項
+
+### レスポンシブデザイン
+- モバイルでもD&D操作が快適
+- タブ切り替えがタッチデバイスで操作しやすい
+- セットリスト選択ドロップダウンのタッチ対応
+
+### アクセシビリティ
+- キーボードナビゲーション対応
+- スクリーンリーダー対応
+- 適切なaria-label設定
+
+### パフォーマンス
+- 大量セットリスト時の仮想化検討
+- D&D操作時のスムーズなアニメーション
+- 楽譜表示切り替えの高速化
+
+## 将来の拡張可能性
+
+### セットリスト機能拡張
+- セットリスト複製機能
+- セットリストエクスポート・インポート
+- セットリスト編集機能（楽譜追加・削除）の復活検討
+
+### 高度な機能
+- セットリスト共有機能
+- セットリスト統計（演奏時間等）
+- セットリストテンプレート機能
+
+---
+
+この設計により、既存機能を損なうことなく、直感的で使いやすいセットリスト機能を追加できます。

--- a/src/stores/__tests__/setListStore.test.ts
+++ b/src/stores/__tests__/setListStore.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useSetListStore } from '../setListStore';
+import { logger } from '../../utils/logger';
+
+// loggerをモック化
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('useSetListStore', () => {
+  beforeEach(() => {
+    // ストアをリセット
+    useSetListStore.getState().clearSetLists();
+    vi.clearAllMocks();
+  });
+
+  describe('createSetList', () => {
+    it('セットリストを作成できる', async () => {
+      const store = useSetListStore.getState();
+      const chartIds = ['chart1', 'chart2', 'chart3'];
+      
+      const setListId = await store.createSetList('Test SetList', chartIds);
+      
+      expect(setListId).toMatch(/^setlist-\d+-[a-f0-9]+$/);
+      
+      const { setLists, currentSetListId } = useSetListStore.getState();
+      
+      expect(setLists[setListId]).toBeDefined();
+      expect(setLists[setListId].name).toBe('Test SetList');
+      expect(setLists[setListId].chartIds).toEqual(chartIds);
+      expect(setLists[setListId].createdAt).toBeInstanceOf(Date);
+      expect(currentSetListId).toBe(setListId);
+      
+      expect(logger.info).toHaveBeenCalledWith(
+        'セットリストを作成しました: Test SetList',
+        { id: setListId, chartIds }
+      );
+    });
+
+    it('空のchartIdsでもセットリストを作成できる', async () => {
+      const store = useSetListStore.getState();
+      
+      const setListId = await store.createSetList('Empty SetList', []);
+      
+      const { setLists } = useSetListStore.getState();
+      
+      expect(setLists[setListId].chartIds).toEqual([]);
+    });
+  });
+
+  describe('deleteSetList', () => {
+    it('セットリストを削除できる', async () => {
+      const store = useSetListStore.getState();
+      
+      // セットリストを作成
+      const setListId = await store.createSetList('Test SetList', ['chart1']);
+      
+      // 削除前の確認
+      expect(useSetListStore.getState().setLists[setListId]).toBeDefined();
+      expect(useSetListStore.getState().currentSetListId).toBe(setListId);
+      
+      // 削除実行
+      await store.deleteSetList(setListId);
+      
+      // 削除後の確認
+      const { setLists, currentSetListId } = useSetListStore.getState();
+      expect(setLists[setListId]).toBeUndefined();
+      expect(currentSetListId).toBeNull();
+      
+      expect(logger.info).toHaveBeenCalledWith(`セットリストを削除しました: ${setListId}`);
+    });
+
+    it('現在選択中でないセットリストを削除した場合、currentSetListIdは変更されない', async () => {
+      const store = useSetListStore.getState();
+      
+      // 2つのセットリストを作成
+      const setListId1 = await store.createSetList('SetList 1', ['chart1']);
+      const setListId2 = await store.createSetList('SetList 2', ['chart2']);
+      
+      // 1つ目を現在選択中に設定
+      store.setCurrentSetList(setListId1);
+      
+      // 2つ目を削除
+      await store.deleteSetList(setListId2);
+      
+      // 1つ目はまだ選択中のまま
+      expect(useSetListStore.getState().currentSetListId).toBe(setListId1);
+    });
+
+    it('存在しないセットリストの削除を試みた場合、警告ログが出力される', async () => {
+      const store = useSetListStore.getState();
+      
+      await store.deleteSetList('non-existent-id');
+      
+      expect(logger.warn).toHaveBeenCalledWith(
+        '削除対象のセットリストが見つかりません: non-existent-id'
+      );
+    });
+  });
+
+  describe('updateSetListOrder', () => {
+    it('セットリストの楽譜順序を更新できる', async () => {
+      const store = useSetListStore.getState();
+      
+      // セットリストを作成
+      const originalOrder = ['chart1', 'chart2', 'chart3'];
+      const setListId = await store.createSetList('Test SetList', originalOrder);
+      
+      // 順序を変更
+      const newOrder = ['chart3', 'chart1', 'chart2'];
+      await store.updateSetListOrder(setListId, newOrder);
+      
+      // 変更後の確認
+      const { setLists } = useSetListStore.getState();
+      expect(setLists[setListId].chartIds).toEqual(newOrder);
+      
+      expect(logger.info).toHaveBeenCalledWith(`セットリストの順序を更新しました: ${setListId}`);
+    });
+
+    it('存在しないセットリストの順序更新を試みた場合、警告ログが出力される', async () => {
+      const store = useSetListStore.getState();
+      
+      await store.updateSetListOrder('non-existent-id', ['chart1']);
+      
+      expect(logger.warn).toHaveBeenCalledWith(
+        '更新対象のセットリストが見つかりません: non-existent-id'
+      );
+    });
+  });
+
+  describe('setCurrentSetList', () => {
+    it('現在のセットリストを設定できる', () => {
+      const store = useSetListStore.getState();
+      
+      store.setCurrentSetList('test-id');
+      
+      expect(useSetListStore.getState().currentSetListId).toBe('test-id');
+      expect(logger.debug).toHaveBeenCalledWith('現在のセットリストを設定: test-id');
+    });
+
+    it('現在のセットリストをnullに設定できる', () => {
+      const store = useSetListStore.getState();
+      
+      // 最初に何かを設定
+      store.setCurrentSetList('test-id');
+      
+      // nullに設定
+      store.setCurrentSetList(null);
+      
+      expect(useSetListStore.getState().currentSetListId).toBeNull();
+      expect(logger.debug).toHaveBeenCalledWith('現在のセットリストを設定: null');
+    });
+  });
+
+  describe('setSetLists', () => {
+    it('セットリストを一括設定できる', () => {
+      const store = useSetListStore.getState();
+      
+      const setLists = {
+        'setlist1': {
+          id: 'setlist1',
+          name: 'SetList 1',
+          chartIds: ['chart1', 'chart2'],
+          createdAt: new Date(),
+        },
+        'setlist2': {
+          id: 'setlist2',
+          name: 'SetList 2',
+          chartIds: ['chart3'],
+          createdAt: new Date(),
+        },
+      };
+      
+      store.setSetLists(setLists);
+      
+      expect(useSetListStore.getState().setLists).toEqual(setLists);
+      expect(logger.debug).toHaveBeenCalledWith(
+        'セットリストを設定しました',
+        { count: 2 }
+      );
+    });
+  });
+
+  describe('clearSetLists', () => {
+    it('セットリストをクリアできる', async () => {
+      const store = useSetListStore.getState();
+      
+      // セットリストを作成
+      await store.createSetList('Test SetList', ['chart1']);
+      
+      // クリア前の確認
+      expect(Object.keys(useSetListStore.getState().setLists)).toHaveLength(1);
+      expect(useSetListStore.getState().currentSetListId).not.toBeNull();
+      
+      // クリア実行
+      store.clearSetLists();
+      
+      // クリア後の確認
+      const { setLists, currentSetListId } = useSetListStore.getState();
+      expect(setLists).toEqual({});
+      expect(currentSetListId).toBeNull();
+      
+      expect(logger.debug).toHaveBeenCalledWith('セットリストをクリアしました');
+    });
+  });
+});

--- a/src/stores/setListStore.ts
+++ b/src/stores/setListStore.ts
@@ -1,0 +1,123 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import type { SetList, SetListLibrary } from '../types/setList';
+import { logger } from '../utils/logger';
+import { v4 as uuidv4 } from 'uuid';
+
+interface SetListState {
+  /** セットリストの辞書 */
+  setLists: SetListLibrary;
+  /** 現在選択中のセットリストID */
+  currentSetListId: string | null;
+
+  // アクション
+  /** セットリストを作成 */
+  createSetList: (name: string, chartIds: string[]) => Promise<string>;
+  /** セットリストを削除 */
+  deleteSetList: (id: string) => Promise<void>;
+  /** セットリストの楽譜順序を更新 */
+  updateSetListOrder: (id: string, newChartIds: string[]) => Promise<void>;
+  /** 現在のセットリストを設定 */
+  setCurrentSetList: (id: string | null) => void;
+  /** セットリストを設定（ストレージからの読み込み用） */
+  setSetLists: (setLists: SetListLibrary) => void;
+  /** セットリストをクリア */
+  clearSetLists: () => void;
+}
+
+/**
+ * セットリストIDを生成
+ */
+const generateSetListId = (): string => {
+  const timestamp = Date.now();
+  const random = uuidv4().split('-')[0];
+  return `setlist-${timestamp}-${random}`;
+};
+
+/**
+ * セットリストストア
+ */
+export const useSetListStore = create<SetListState>()(
+  devtools((set, get) => ({
+    setLists: {},
+    currentSetListId: null,
+
+    createSetList: async (name: string, chartIds: string[]) => {
+      const id = generateSetListId();
+      const newSetList: SetList = {
+        id,
+        name,
+        chartIds,
+        createdAt: new Date(),
+      };
+
+      set((state) => ({
+        setLists: {
+          ...state.setLists,
+          [id]: newSetList,
+        },
+        currentSetListId: id,
+      }));
+
+      logger.info(`セットリストを作成しました: ${name}`, { id, chartIds });
+      return id;
+    },
+
+    deleteSetList: async (id: string) => {
+      const { setLists, currentSetListId } = get();
+      
+      if (!setLists[id]) {
+        logger.warn(`削除対象のセットリストが見つかりません: ${id}`);
+        return;
+      }
+
+      const newSetLists = { ...setLists };
+      delete newSetLists[id];
+
+      set({
+        setLists: newSetLists,
+        currentSetListId: currentSetListId === id ? null : currentSetListId,
+      });
+
+      logger.info(`セットリストを削除しました: ${id}`);
+    },
+
+    updateSetListOrder: async (id: string, newChartIds: string[]) => {
+      const { setLists } = get();
+      
+      if (!setLists[id]) {
+        logger.warn(`更新対象のセットリストが見つかりません: ${id}`);
+        return;
+      }
+
+      set((state) => ({
+        setLists: {
+          ...state.setLists,
+          [id]: {
+            ...state.setLists[id],
+            chartIds: newChartIds,
+          },
+        },
+      }));
+
+      logger.info(`セットリストの順序を更新しました: ${id}`);
+    },
+
+    setCurrentSetList: (id: string | null) => {
+      set({ currentSetListId: id });
+      logger.debug(`現在のセットリストを設定: ${id}`);
+    },
+
+    setSetLists: (setLists: SetListLibrary) => {
+      set({ setLists });
+      logger.debug('セットリストを設定しました', { count: Object.keys(setLists).length });
+    },
+
+    clearSetLists: () => {
+      set({ setLists: {}, currentSetListId: null });
+      logger.debug('セットリストをクリアしました');
+    },
+  }), {
+    name: 'setListStore',
+  })
+);

--- a/src/types/setList.ts
+++ b/src/types/setList.ts
@@ -1,0 +1,46 @@
+// セットリスト機能の型定義
+
+/**
+ * セットリスト - 楽譜のセットを管理するための型
+ */
+export interface SetList {
+  /** ユニークID（'setlist-' + timestamp + random） */
+  id: string;
+  /** セットリスト名 */
+  name: string;
+  /** 楽譜IDの配列（順序を保持） */
+  chartIds: string[];
+  /** 作成日時 */
+  createdAt: Date;
+}
+
+/**
+ * セットリストのライブラリ - SetList.idをキーとした辞書
+ */
+export interface SetListLibrary {
+  [key: string]: SetList;
+}
+
+/**
+ * LocalForageに保存するセットリストデータの構造
+ */
+export interface StoredSetListData {
+  /** データ構造のバージョン（マイグレーション用） */
+  version: string;
+  /** セットリストの辞書 */
+  setLists: SetListLibrary;
+  /** 現在選択中のセットリストID */
+  currentSetListId: string | null;
+}
+
+/**
+ * Dropbox同期用のセットリストデータ構造
+ */
+export interface SyncSetListData {
+  /** データ構造のバージョン */
+  version: string;
+  /** セットリストの辞書 */
+  setLists: SetListLibrary;
+  /** 同期日時（ISO 8601形式） */
+  syncedAt: string;
+}

--- a/src/utils/__tests__/setListStorage.test.ts
+++ b/src/utils/__tests__/setListStorage.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import localForage from 'localforage';
+import {
+  loadSetListsFromStorage,
+  saveSetListsToStorage,
+  clearSetListsFromStorage,
+} from '../setListStorage';
+import type { SetListLibrary, StoredSetListData } from '../../types/setList';
+import { logger } from '../logger';
+
+// localForageをモック化
+vi.mock('localforage', () => ({
+  default: {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+// loggerをモック化
+vi.mock('../logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockedLocalForage = localForage as unknown as {
+  getItem: Mock;
+  setItem: Mock;
+  removeItem: Mock;
+};
+
+describe('setListStorage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('loadSetListsFromStorage', () => {
+    it('データが存在しない場合、デフォルトデータを返す', async () => {
+      mockedLocalForage.getItem.mockResolvedValue(null);
+
+      const result = await loadSetListsFromStorage();
+
+      expect(result).toEqual({
+        version: '1.0.0',
+        setLists: {},
+        currentSetListId: null,
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'セットリストデータが見つかりません。デフォルトデータを返します。'
+      );
+    });
+
+    it('正常なデータを読み込める', async () => {
+      const testData: StoredSetListData = {
+        version: '1.0.0',
+        setLists: {
+          'setlist1': {
+            id: 'setlist1',
+            name: 'Test SetList',
+            chartIds: ['chart1', 'chart2'],
+            createdAt: new Date('2024-01-01'),
+          },
+        },
+        currentSetListId: 'setlist1',
+      };
+
+      mockedLocalForage.getItem.mockResolvedValue(testData);
+
+      const result = await loadSetListsFromStorage();
+
+      expect(result).toEqual(testData);
+      expect(logger.debug).toHaveBeenCalledWith(
+        'セットリストデータを読み込みました',
+        {
+          count: 1,
+          currentSetListId: 'setlist1',
+        }
+      );
+    });
+
+    it('バージョンが異なる場合、警告ログを出力してデフォルトデータを返す', async () => {
+      const testData: StoredSetListData = {
+        version: '0.9.0', // 古いバージョン
+        setLists: {
+          'setlist1': {
+            id: 'setlist1',
+            name: 'Test SetList',
+            chartIds: ['chart1'],
+            createdAt: new Date('2024-01-01'),
+          },
+        },
+        currentSetListId: 'setlist1',
+      };
+
+      mockedLocalForage.getItem.mockResolvedValue(testData);
+
+      const result = await loadSetListsFromStorage();
+
+      expect(result).toEqual({
+        version: '1.0.0',
+        setLists: {},
+        currentSetListId: null,
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        'セットリストデータのバージョンが異なります: 0.9.0 → 1.0.0'
+      );
+    });
+
+    it('読み込みエラーが発生した場合、エラーログを出力してデフォルトデータを返す', async () => {
+      const error = new Error('Storage error');
+      mockedLocalForage.getItem.mockRejectedValue(error);
+
+      const result = await loadSetListsFromStorage();
+
+      expect(result).toEqual({
+        version: '1.0.0',
+        setLists: {},
+        currentSetListId: null,
+      });
+      expect(logger.error).toHaveBeenCalledWith(
+        'セットリストデータの読み込みに失敗しました',
+        error
+      );
+    });
+  });
+
+  describe('saveSetListsToStorage', () => {
+    it('セットリストデータを保存できる', async () => {
+      const setLists: SetListLibrary = {
+        'setlist1': {
+          id: 'setlist1',
+          name: 'Test SetList',
+          chartIds: ['chart1', 'chart2'],
+          createdAt: new Date('2024-01-01'),
+        },
+      };
+      const currentSetListId = 'setlist1';
+
+      mockedLocalForage.setItem.mockResolvedValue(undefined);
+
+      await saveSetListsToStorage(setLists, currentSetListId);
+
+      expect(mockedLocalForage.setItem).toHaveBeenCalledWith(
+        'nekogata-setlists',
+        {
+          version: '1.0.0',
+          setLists,
+          currentSetListId,
+        }
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        'セットリストデータを保存しました',
+        {
+          count: 1,
+          currentSetListId: 'setlist1',
+        }
+      );
+    });
+
+    it('currentSetListIdが指定されない場合、nullで保存される', async () => {
+      const setLists: SetListLibrary = {};
+
+      mockedLocalForage.setItem.mockResolvedValue(undefined);
+
+      await saveSetListsToStorage(setLists);
+
+      expect(mockedLocalForage.setItem).toHaveBeenCalledWith(
+        'nekogata-setlists',
+        {
+          version: '1.0.0',
+          setLists,
+          currentSetListId: null,
+        }
+      );
+    });
+
+    it('保存エラーが発生した場合、エラーログを出力してエラーを再throw', async () => {
+      const error = new Error('Storage error');
+      const setLists: SetListLibrary = {};
+
+      mockedLocalForage.setItem.mockRejectedValue(error);
+
+      await expect(saveSetListsToStorage(setLists)).rejects.toThrow('Storage error');
+      expect(logger.error).toHaveBeenCalledWith(
+        'セットリストデータの保存に失敗しました',
+        error
+      );
+    });
+  });
+
+  describe('clearSetListsFromStorage', () => {
+    it('セットリストデータを削除できる', async () => {
+      mockedLocalForage.removeItem.mockResolvedValue(undefined);
+
+      await clearSetListsFromStorage();
+
+      expect(mockedLocalForage.removeItem).toHaveBeenCalledWith('nekogata-setlists');
+      expect(logger.debug).toHaveBeenCalledWith('セットリストデータを削除しました');
+    });
+
+    it('削除エラーが発生した場合、エラーログを出力してエラーを再throw', async () => {
+      const error = new Error('Storage error');
+      mockedLocalForage.removeItem.mockRejectedValue(error);
+
+      await expect(clearSetListsFromStorage()).rejects.toThrow('Storage error');
+      expect(logger.error).toHaveBeenCalledWith(
+        'セットリストデータの削除に失敗しました',
+        error
+      );
+    });
+  });
+});

--- a/src/utils/setListStorage.ts
+++ b/src/utils/setListStorage.ts
@@ -1,0 +1,88 @@
+import localForage from 'localforage';
+import type { SetListLibrary, StoredSetListData } from '../types/setList';
+import { logger } from './logger';
+
+/** セットリストデータの保存キー */
+const SETLIST_STORAGE_KEY = 'nekogata-setlists';
+
+/** 現在のデータバージョン */
+const CURRENT_VERSION = '1.0.0';
+
+/**
+ * デフォルトのセットリストデータ
+ */
+const getDefaultSetListData = (): StoredSetListData => ({
+  version: CURRENT_VERSION,
+  setLists: {},
+  currentSetListId: null,
+});
+
+/**
+ * セットリストデータをLocalForageから読み込む
+ */
+export const loadSetListsFromStorage = async (): Promise<StoredSetListData> => {
+  try {
+    const data = await localForage.getItem<StoredSetListData>(SETLIST_STORAGE_KEY);
+    
+    if (!data) {
+      logger.debug('セットリストデータが見つかりません。デフォルトデータを返します。');
+      return getDefaultSetListData();
+    }
+
+    // バージョンチェック（将来的にマイグレーション処理を追加）
+    if (data.version !== CURRENT_VERSION) {
+      logger.warn(`セットリストデータのバージョンが異なります: ${data.version} → ${CURRENT_VERSION}`);
+      // 現在は単純にデフォルトデータを返すが、将来的にマイグレーション処理を追加
+      return getDefaultSetListData();
+    }
+
+    logger.debug('セットリストデータを読み込みました', { 
+      count: Object.keys(data.setLists).length,
+      currentSetListId: data.currentSetListId 
+    });
+    
+    return data;
+  } catch (error) {
+    logger.error('セットリストデータの読み込みに失敗しました', error);
+    return getDefaultSetListData();
+  }
+};
+
+/**
+ * セットリストデータをLocalForageに保存する
+ */
+export const saveSetListsToStorage = async (
+  setLists: SetListLibrary,
+  currentSetListId: string | null = null
+): Promise<void> => {
+  try {
+    const data: StoredSetListData = {
+      version: CURRENT_VERSION,
+      setLists,
+      currentSetListId,
+    };
+
+    await localForage.setItem(SETLIST_STORAGE_KEY, data);
+    
+    logger.debug('セットリストデータを保存しました', { 
+      count: Object.keys(setLists).length,
+      currentSetListId 
+    });
+  } catch (error) {
+    logger.error('セットリストデータの保存に失敗しました', error);
+    throw error;
+  }
+};
+
+/**
+ * セットリストデータをLocalForageから削除する
+ */
+export const clearSetListsFromStorage = async (): Promise<void> => {
+  try {
+    await localForage.removeItem(SETLIST_STORAGE_KEY);
+    logger.debug('セットリストデータを削除しました');
+  } catch (error) {
+    logger.error('セットリストデータの削除に失敗しました', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary

セットリスト機能実装の第1段階として、データモデルとストアの基盤部分を実装しました。

- セットリスト用の型定義とインターフェースの追加
- Zustandを使用したセットリスト管理ストアの実装
- LocalForageとの連携による永続化機能
- 包括的なユニットテスト（ストア操作とストレージ機能）

## Changes

### 新規ファイル
- `src/types/setList.ts`: セットリスト関連の型定義
- `src/stores/setListStore.ts`: セットリスト管理用Zustandストア
- `src/utils/setListStorage.ts`: LocalForage連携とデータ永続化
- `src/stores/__tests__/setListStore.test.ts`: ストアのユニットテスト
- `src/utils/__tests__/setListStorage.test.ts`: ストレージのユニットテスト

### 実装機能
- セットリスト作成・削除・順序更新のCRUD操作
- LocalForageによるブラウザ永続化
- データバージョン管理とマイグレーション対応
- 適切なエラーハンドリングとログ出力
- TypeScript型安全性の確保

## Test plan

- [x] ユニットテスト実行: `npm test` ✅
- [x] コード品質チェック: `npm run lint` ✅  
- [x] ビルド確認: `npm run build` ✅
- [x] ストア操作の各種テストケース
- [x] ストレージ連携の正常・異常系テスト

## 次のステップ

続けてPR2でUI実装（タブ・セレクター・作成機能）を進める予定です。

🤖 Generated with [Claude Code](https://claude.ai/code)