### PR TITLE
refactor: Knipで検出された未使用コードを削除

### DIFF
--- a/src/test-utils/chord-test-helpers.ts
+++ b/src/test-utils/chord-test-helpers.ts
@@ -20,39 +20,3 @@ export function createTestChords(chords: Array<Omit<StoredChord, 'memo'> & { mem
   return chords.map(createTestChord);
 }
 
-/**
- * よく使うコード進行のプリセット
- */
-export const TEST_CHORD_PROGRESSIONS = {
-  // C-Am-F-G (ポップスの定番進行)
-  popProgression: () => createTestChords([
-    { name: 'C', root: 'C', duration: 4 },
-    { name: 'Am', root: 'A', duration: 4 },
-    { name: 'F', root: 'F', duration: 4 },
-    { name: 'G', root: 'G', duration: 4 }
-  ]),
-  
-  // C-G-Am-F (カノン進行)
-  canonProgression: () => createTestChords([
-    { name: 'C', root: 'C', duration: 4 },
-    { name: 'G', root: 'G', duration: 4 },
-    { name: 'Am', root: 'A', duration: 4 },
-    { name: 'F', root: 'F', duration: 4 }
-  ]),
-  
-  // オンコードを含む進行
-  onChordProgression: () => createTestChords([
-    { name: 'C', root: 'C', duration: 4 },
-    { name: 'G/B', root: 'G', base: 'B', duration: 4 },
-    { name: 'Am', root: 'A', duration: 4 },
-    { name: 'F', root: 'F', duration: 4 }
-  ]),
-  
-  // 短い拍数のコード
-  shortDurationChords: () => createTestChords([
-    { name: 'C', root: 'C', duration: 2 },
-    { name: 'G', root: 'G', duration: 2 },
-    { name: 'Am', root: 'A', duration: 1 },
-    { name: 'F', root: 'F', duration: 3 }
-  ])
-};

--- a/src/types/setList.ts
+++ b/src/types/setList.ts
@@ -35,14 +35,3 @@ export interface StoredSetListData {
   currentSetListId: string | null;
 }
 
-/**
- * Dropbox同期用のセットリストデータ構造
- */
-export interface SyncSetListData {
-  /** データ構造のバージョン */
-  version: string;
-  /** セットリストの辞書 */
-  setLists: SetListLibrary;
-  /** 同期日時（ISO 8601形式） */
-  syncedAt: string;
-}

--- a/src/utils/chordConversion.ts
+++ b/src/utils/chordConversion.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import type { StoredChord, DisplayChord, ChordSection } from '../types';
+import type { StoredChord, DisplayChord } from '../types';
 
 /**
  * 保存用ChordからUI表示用Chordに変換（idを生成）
@@ -11,31 +11,5 @@ export function toDisplayChord(storedChord: StoredChord): DisplayChord {
   };
 }
 
-/**
- * UI表示用Chordから保存用Chordに変換（idを除去）
- */
-export function toStoredChord(displayChord: DisplayChord): StoredChord {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { id, ...storedChord } = displayChord;
-  return storedChord;
-}
 
-/**
- * ChordSectionの全コードをUI表示用に変換
- */
-export function toDisplaySection(section: Omit<ChordSection, 'chords'> & { chords: StoredChord[] }): ChordSection {
-  return {
-    ...section,
-    chords: section.chords.map(toDisplayChord)
-  };
-}
 
-/**
- * ChordSectionの全コードを保存用に変換
- */
-export function toStoredSection(section: ChordSection): Omit<ChordSection, 'chords'> & { chords: StoredChord[] } {
-  return {
-    ...section,
-    chords: section.chords.map(toStoredChord)
-  };
-}


### PR DESCRIPTION
## Summary
Knipで検出された未使用コードを削除し、コードベースを整理しました。

## 変更内容
- **TEST_CHORD_PROGRESSIONS**: テストヘルパーファイルで定義されているが使用されていない定数を削除
- **toStoredChord, toDisplaySection, toStoredSection**: 変換ユーティリティで定義されているが使用されていない関数を削除  
- **SyncSetListData**: 同期機能の型定義で定義されているが使用されていないインターフェースを削除
- **不要なimport**: 削除した関数に関連する不要なimportも併せて削除

## Test plan
- [x] 全てのユニットテストが成功することを確認
- [x] リントチェックが成功することを確認
- [x] ビルドが成功することを確認
- [x] Knipで未使用コードの警告が出力されないことを確認

## 影響範囲
削除したコードはすべて未使用のため、機能への影響はありません。

🤖 Generated with [Claude Code](https://claude.ai/code)