### PR TITLE
fix: BPM入力フィールドで空白時に自動的に120が入力される問題を修正

### DIFF
--- a/src/components/ChordChartForm.tsx
+++ b/src/components/ChordChartForm.tsx
@@ -49,7 +49,7 @@ const ChordChartForm: React.FC<ChordChartFormProps> = ({
     }
   };
 
-  const handleChange = (field: string, value: string | number) => {
+  const handleChange = (field: string, value: string | number | undefined) => {
     setFormData(prev => ({ ...prev, [field]: value }));
     if (errors.length > 0) {
       setErrors([]);
@@ -130,7 +130,17 @@ const ChordChartForm: React.FC<ChordChartFormProps> = ({
                 id="tempo"
                 type="number"
                 value={formData.tempo}
-                onChange={(e) => handleChange('tempo', parseInt(e.target.value) || 120)}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  if (value === '') {
+                    handleChange('tempo', undefined);
+                  } else {
+                    const parsed = parseInt(value);
+                    if (!isNaN(parsed)) {
+                      handleChange('tempo', parsed);
+                    }
+                  }
+                }}
                 min="40"
                 max="200"
                 className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#85B0B7]"

--- a/src/utils/chordCreation.ts
+++ b/src/utils/chordCreation.ts
@@ -35,6 +35,8 @@ export const createNewChordChart = (
     id: uuidv4(),
     ...empty,
     ...data,
+    // tempoが未定義の場合はデフォルト値を使用
+    tempo: data.tempo !== undefined ? data.tempo : empty.tempo,
     // sectionsが未定義の場合はデフォルトセクションを使用
     sections: data.sections || empty.sections,
     createdAt: now,


### PR DESCRIPTION
## 概要
BPM入力フィールドでバックスペースで値を削除した際に、空白になると自動的に120が入力されてしまう問題を修正しました。

## 問題の詳細
- ユーザーがBPM入力フィールドの値をバックスペースで削除すると、空白になった瞬間に自動的に120が入力される
- これは`parseInt(e.target.value) || 120`のロジックにより、空文字列がNaNになり、結果として120が設定されるため

## 変更内容
1. **ChordChartForm.tsx**
   - onChange処理を改善し、空文字列の場合はundefinedを設定
   - 数値以外の入力は無視するように変更
   - handleChange関数の型定義にundefinedを追加

2. **chordCreation.ts**
   - createNewChordChart関数でtempoがundefinedの場合のみデフォルト値120を適用
   - これにより、ユーザーが意図的に空にした場合は空のまま保持される

## テスト計画
- [x] BPM入力フィールドでバックスペースで値を削除しても120が自動入力されないことを確認
- [x] 数値入力が正常に動作することを確認
- [x] フォーム送信時にBPMが未入力の場合、デフォルト値120が適用されることを確認
- [x] lint、buildが正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)