### PR TITLE
feat: 文字サイズ変更時の自動同期をスキップする機能を追加

### DIFF
--- a/src/components/ChordChartViewer.tsx
+++ b/src/components/ChordChartViewer.tsx
@@ -24,7 +24,7 @@ const ChordChartViewer: React.FC<ChordChartViewerProps> = ({ chart, currentChart
   const handleFontSizeChange = async (newSize: number) => {
     setFontSize(newSize);
     if (currentChartId) {
-      await updateChart(currentChartId, { fontSize: newSize });
+      await updateChart(currentChartId, { fontSize: newSize }, true);
     }
   };
 

--- a/src/stores/chartCrudStore.ts
+++ b/src/stores/chartCrudStore.ts
@@ -14,7 +14,7 @@ interface ChartCrudState {
   
   // CRUD操作
   addChart: (chart: ChordChart) => Promise<void>;
-  updateChart: (id: string, chartUpdate: Partial<ChordChart>) => Promise<void>;
+  updateChart: (id: string, chartUpdate: Partial<ChordChart>, skipSync?: boolean) => Promise<void>;
   deleteChart: (id: string) => Promise<void>;
   deleteMultipleCharts: (ids: string[]) => Promise<void>;
   createNewChart: (chartData: Partial<ChordChart>) => Promise<ChordChart>;
@@ -63,7 +63,7 @@ export const useChartCrudStore = create<ChartCrudState>()(
         }
       },
       
-      updateChart: async (id: string, chartUpdate: Partial<ChordChart>) => {
+      updateChart: async (id: string, chartUpdate: Partial<ChordChart>, skipSync = false) => {
         try {
           set({ isLoading: true, error: null });
           
@@ -80,8 +80,10 @@ export const useChartCrudStore = create<ChartCrudState>()(
           // データストアを更新
           dataStore.updateChartInData(id, updatedChart);
           
-          // 同期通知
-          get().notifySyncCallbacks();
+          // 同期通知（skipSyncがfalseの場合のみ）
+          if (!skipSync) {
+            get().notifySyncCallbacks();
+          }
           
           set({ isLoading: false });
         } catch (error) {


### PR DESCRIPTION
## 概要
文字サイズ（フォントサイズ）の変更時に自動同期が実行されないように改善しました。

## 背景
文字サイズの変更は表示設定の変更であり、楽譜データの本質的な変更ではありません。
頻繁な文字サイズ調整時に毎回同期が実行されると、パフォーマンスへの影響や不要なネットワーク通信が発生します。

## 変更内容
1. **chartCrudStore.ts**
   - `updateChart`メソッドに`skipSync`オプショナルパラメータを追加
   - `skipSync`がtrueの場合は同期通知をスキップ

2. **ChordChartViewer.tsx**
   - `handleFontSizeChange`でupdateChartを呼び出す際に`skipSync=true`を指定

## テスト計画
- [x] 文字サイズ変更が正常に動作することを確認
- [x] 文字サイズ変更時に自動同期がトリガーされないことを確認
- [x] 他のチャート更新時は通常通り自動同期が動作することを確認
- [x] 全ユニットテストが通過することを確認
- [x] 全E2Eテストが通過することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)