### PR TITLE
feat: N.C. (No Chord) のサポートを追加

### DIFF
--- a/src/utils/__tests__/chordParsing.test.ts
+++ b/src/utils/__tests__/chordParsing.test.ts
@@ -23,6 +23,13 @@ describe('chordParsing', () => {
       expect(extractChordRoot('Bbm7(b5)')).toBe('B♭');
     });
 
+    it('should handle N.C. (No Chord)', () => {
+      expect(extractChordRoot('N.C.')).toBe('N.C.');
+      expect(extractChordRoot('NC')).toBe('N.C.');
+      expect(extractChordRoot('n.c.')).toBe('N.C.');
+      expect(extractChordRoot('nc')).toBe('N.C.');
+    });
+
     it('should return default for invalid input', () => {
       expect(extractChordRoot('')).toBe('C');
       expect(extractChordRoot('invalid')).toBe('C');
@@ -176,7 +183,9 @@ describe('chordParsing', () => {
           { input: 'Gaug', expected: { name: 'Gaug', root: 'G' } },
           { input: 'Csus4', expected: { name: 'Csus4', root: 'C' } },
           { input: 'Asus2', expected: { name: 'Asus2', root: 'A' } },
-          { input: 'Cadd9', expected: { name: 'Cadd9', root: 'C' } }
+          { input: 'Cadd9', expected: { name: 'Cadd9', root: 'C' } },
+          { input: 'N.C.', expected: { name: 'N.C.', root: 'N.C.' } },
+          { input: 'NC', expected: { name: 'NC', root: 'N.C.' } }
         ];
 
         for (const { input, expected } of testCases) {

--- a/src/utils/__tests__/chordValidation.test.ts
+++ b/src/utils/__tests__/chordValidation.test.ts
@@ -18,6 +18,11 @@ describe('chordValidation', () => {
       expect(isValidChordName('G7')).toBe(true);
       expect(isValidChordName('Am7')).toBe(true);
       expect(isValidChordName('Cmaj7')).toBe(true);
+      // N.C. (No Chord) のテスト
+      expect(isValidChordName('N.C.')).toBe(true);
+      expect(isValidChordName('NC')).toBe(true);
+      expect(isValidChordName('n.c.')).toBe(true);
+      expect(isValidChordName('nc')).toBe(true);
     });
 
     it('無効なコード名を正しく判定する', () => {

--- a/src/utils/__tests__/transpose.test.ts
+++ b/src/utils/__tests__/transpose.test.ts
@@ -46,6 +46,13 @@ describe('移調機能のテスト', () => {
       expect(transposeChordName('', 2, 'D')).toBe('C');
       expect(transposeChordName('Invalid', 2, 'D')).toBe('Invalid');
     });
+
+    test('N.C. (No Chord) の処理', () => {
+      expect(transposeChordName('N.C.', 2, 'D')).toBe('N.C.');
+      expect(transposeChordName('NC', 5, 'F')).toBe('NC');
+      expect(transposeChordName('n.c.', -3, 'A')).toBe('n.c.');
+      expect(transposeChordName('nc', 7, 'G')).toBe('nc');
+    });
   });
 
   describe('calculateSemitonesDifference', () => {
@@ -140,6 +147,27 @@ describe('移調機能のテスト', () => {
       expect(lineBreakChord.isLineBreak).toBe(true);
       expect(lineBreakChord.name).toBe('');
       expect(lineBreakChord.root).toBe('');
+    });
+
+    test('N.C. (No Chord) を含むコード譜の移調', () => {
+      const chart = createTestChart();
+      chart.sections[0].chords = [
+        { id: 'chord-1', name: 'C', root: 'C', duration: 2, memo: '' },
+        { id: 'chord-2', name: 'N.C.', root: 'N.C.', duration: 2, memo: '' },
+        { id: 'chord-3', name: 'G', root: 'G', duration: 2, memo: '' },
+        { id: 'chord-4', name: 'NC', root: 'N.C.', duration: 2, memo: '' }
+      ];
+
+      const transposed = transposeChart(chart, 'D');
+      
+      expect(transposed.sections[0].chords[0].name).toBe('D');
+      expect(transposed.sections[0].chords[0].root).toBe('D');
+      expect(transposed.sections[0].chords[1].name).toBe('N.C.');
+      expect(transposed.sections[0].chords[1].root).toBe('N.C.');
+      expect(transposed.sections[0].chords[2].name).toBe('A');
+      expect(transposed.sections[0].chords[2].root).toBe('A');
+      expect(transposed.sections[0].chords[3].name).toBe('NC');
+      expect(transposed.sections[0].chords[3].root).toBe('N.C.');
     });
 
     test('拍数の保持', () => {

--- a/src/utils/chordParsing.ts
+++ b/src/utils/chordParsing.ts
@@ -12,8 +12,15 @@ export const extractChordRoot = (chordName: string): string => {
     return 'C'; // デフォルト値
   }
 
+  const trimmed = chordName.trim();
+  
+  // N.C. (No Chord) の場合はnullを返す
+  if (trimmed.toUpperCase() === 'N.C.' || trimmed.toUpperCase() === 'NC') {
+    return 'N.C.';
+  }
+
   // ルート音のパターンにマッチ: A-Gで始まり、#、b、♭のいずれかが続く可能性
-  const rootMatch = chordName.match(/^([A-G][#b♭]?)/i);
+  const rootMatch = trimmed.match(/^([A-G][#b♭]?)/i);
   
   if (rootMatch) {
     const root = rootMatch[1];

--- a/src/utils/chordValidation.ts
+++ b/src/utils/chordValidation.ts
@@ -41,6 +41,11 @@ export const isValidChordName = (chordName: string): boolean => {
     return false;
   }
 
+  // N.C. (No Chord) は有効なコードとして扱う
+  if (trimmed.toUpperCase() === 'N.C.' || trimmed.toUpperCase() === 'NC') {
+    return true;
+  }
+
   // ルート音（A-G）で始まることのみチェック、あとはユーザーの入力をそのまま受け入れる
   const rootPattern = /^[A-G][#b♭]?/i;
   return rootPattern.test(trimmed);

--- a/src/utils/transpose.ts
+++ b/src/utils/transpose.ts
@@ -69,6 +69,11 @@ export const transposeChordName = (chordName: string, semitones: number, targetK
     return 'C';
   }
 
+  // N.C. (No Chord) の場合は移調せずそのまま返す
+  if (trimmed.toUpperCase() === 'N.C.' || trimmed.toUpperCase() === 'NC') {
+    return trimmed;
+  }
+
   // オンコードの場合は分離して処理
   if (isOnChord(trimmed)) {
     const parsed = parseOnChord(trimmed);


### PR DESCRIPTION
## 概要
N.C. (No Chord) を有効なコードとして認識できるようにしました。これにより、楽譜内で休符や無音部分を明示的に記載できるようになります。

## 変更内容
- **バリデーション機能**: `isValidChordName`でN.C.を有効なコードとして認識（N.C., NC, n.c., nc すべてに対応）
- **パース機能**: `extractChordRoot`でN.C.の場合は特別なルート音'N.C.'を返すように実装
- **移調機能**: `transposeChordName`でN.C.は移調しても変化しないよう処理を追加
- **テストケース**: 各機能に対してN.C.の動作を確認するテストを追加

## テスト計画
- [x] ユニットテスト: chordValidation, chordParsing, transpose のテストケースを追加
- [x] 全テストが通過することを確認（`npm test`）
- [x] Lintチェックが通過することを確認（`npm run lint`）
- [x] ビルドが成功することを確認（`npm run build`）
- [x] E2Eテストが通過することを確認（`npm run test:e2e`）

## 動作確認
- N.C.をコードとして入力できることを確認
- N.C.が含まれる楽譜を移調してもN.C.が変化しないことを確認
- 大文字小文字の違い（N.C., NC, n.c., nc）すべてが正しく認識されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)