### PR TITLE
fix: 同期処理での不要な再描画を防ぐ改善

### DIFF
--- a/src/stores/chartCrudStore.ts
+++ b/src/stores/chartCrudStore.ts
@@ -264,9 +264,9 @@ export const useChartCrudStore = create<ChartCrudState>()(
           
           logger.debug(`Chart ID selection: current=${currentChartId}, lastOpened=${lastOpenedChartId}, new=${newCurrentChartId}`);
           
-          // データストアを更新
+          // データストアを更新（変更がある場合のみ）
           logger.debug(`Updating dataStore with new charts...`);
-          dataStore.setCharts(chartsLibrary);
+          dataStore.updateChartsIfChanged(chartsLibrary);
           logger.debug(`Updated dataStore charts`);
           
           dataStore.setCurrentChart(newCurrentChartId);


### PR DESCRIPTION
## 概要
同期処理後、楽譜データに変更がない場合でも再描画が発生する問題を修正しました。

## 問題
- 同期が実行されるたびに、データが同じでも画面全体が再描画されていた
- これによりユーザー体験が損なわれ、画面のちらつきが発生していた

## 解決策
`chartDataStore`に`updateChartsIfChanged`メソッドを追加し、データが実際に変更された場合のみ更新するようにしました。

## 変更内容
### chartDataStore
- `updateChartsIfChanged`メソッドを新規追加
  - 全てのチャートのプロパティを深く比較
  - 基本情報（title, artist, key等）の比較
  - セクション情報（name, beatsPerBar等）の比較
  - コード情報（name, root, duration等）の比較
  - 変更がある場合のみstateを更新

### chartCrudStore
- `applySyncedCharts`メソッドを修正
  - `setCharts`の代わりに`updateChartsIfChanged`を使用

## テスト計画
- [x] 同期処理で変更がない場合、再描画が発生しないことを確認
- [x] 同期処理で変更がある場合、正しく更新されることを確認
- [x] 既存のユニットテストが全て通ることを確認
- [x] E2Eテストが全て通ることを確認
- [x] chartDataStoreのテストが正常に動作することを確認

## 効果
- 不要な再描画の防止によるパフォーマンス向上
- 画面のちらつきが解消され、ユーザー体験が向上
- 同期処理の効率化

🤖 Generated with [Claude Code](https://claude.ai/code)