### PR TITLE
fix: 同期処理でのupdatedAt比較による不要な再描画を修正

### DIFF
--- a/src/stores/chartDataStore.ts
+++ b/src/stores/chartDataStore.ts
@@ -55,15 +55,13 @@ export const useChartDataStore = create<ChartDataState>()(
           const currentChart = currentCharts[id];
           const newChart = charts[id];
           
-          // 基本プロパティの比較
+          // 基本プロパティの比較（updatedAtは除外）
           if (
             currentChart.title !== newChart.title ||
             currentChart.artist !== newChart.artist ||
             currentChart.key !== newChart.key ||
             currentChart.tempo !== newChart.tempo ||
             currentChart.timeSignature !== newChart.timeSignature ||
-            currentChart.createdAt !== newChart.createdAt ||
-            currentChart.updatedAt !== newChart.updatedAt ||
             currentChart.notes !== newChart.notes ||
             currentChart.version !== newChart.version ||
             currentChart.fontSize !== newChart.fontSize


### PR DESCRIPTION
## 概要
同期処理時にupdatedAtとcreatedAtの差異により、実質的な変更がなくても再描画が発生する問題を修正しました。

## 問題
- `updateChartsIfChanged`メソッドでupdatedAtとcreatedAtを比較していた
- 同期時にリモートとローカルでこれらのタイムスタンプが異なると、常に「変更あり」と判定
- 結果として、データに実質的な変更がなくても画面が再描画されていた

## 解決策
- `chartDataStore.ts`の`updateChartsIfChanged`メソッドを改善
- updatedAtとcreatedAtの比較を除外
- 実際のコンテンツ（タイトル、アーティスト、コード進行など）の変更のみを検出

## 変更内容
- `src/stores/chartDataStore.ts`: updatedAtとcreatedAtの比較を削除

## テスト計画
- [x] 同期処理で変更がない場合、再描画が発生しないことを確認
- [x] 同期処理で変更がある場合、正しく更新されることを確認
- [x] chartDataStoreのユニットテストが通ることを確認

## 効果
- 同期後もデータに実質的な変更がない場合は再描画されなくなる
- ユーザー体験の向上（画面のちらつきを防止）
- パフォーマンスの改善

🤖 Generated with [Claude Code](https://claude.ai/code)