### PR TITLE
fix: setCurrentChartで同じIDの場合は更新をスキップする最適化

### DIFF
--- a/src/stores/chartDataStore.ts
+++ b/src/stores/chartDataStore.ts
@@ -127,6 +127,11 @@ export const useChartDataStore = create<ChartDataState>()(
       },
       
       setCurrentChart: (id) => {
+        // 現在のIDと同じ場合は更新をスキップ
+        if (get().currentChartId === id) {
+          return;
+        }
+        
         set({ currentChartId: id }, false, 'setCurrentChart');
         // 最後に開いたチャートIDを保存
         storageService.saveLastOpenedChartId(id).catch(console.error);


### PR DESCRIPTION
## 概要
同期処理の再描画を完全に防ぐため、`setCurrentChart`メソッドを最適化しました。

## 問題
- `setCurrentChart`は常に新しい状態を設定していた
- `currentChartId`が同じでも再描画が発生していた
- 先ほど実装した`updateChartsIfChanged`の最適化効果が十分に活かされていなかった

## 解決策
`chartDataStore.ts`の`setCurrentChart`メソッドに同一ID判定を追加：
```typescript
setCurrentChart: (id) => {
  // 現在のIDと同じ場合は更新をスキップ
  if (get().currentChartId === id) {
    return;
  }
  
  set({ currentChartId: id }, false, 'setCurrentChart');
  // 最後に開いたチャートIDを保存
  storageService.saveLastOpenedChartId(id).catch(console.error);
},
```

## テスト計画
- [x] 同じチャートIDで`setCurrentChart`を呼んでも再描画が発生しないことを確認
- [x] 異なるチャートIDで`setCurrentChart`を呼ぶと正しく更新されることを確認
- [x] chartDataStoreのユニットテストが全て通ることを確認

## 効果
- 同期処理で現在のチャートが変わらない場合（ほとんどのケース）の再描画を完全に防止
- `updateChartsIfChanged`と組み合わせて、同期処理の最適化が完全になりました
- ユーザー体験の向上（画面のちらつきを完全に防止）

## 関連PR
- #219: 同期処理でのupdatedAt比較による不要な再描画を修正

🤖 Generated with [Claude Code](https://claude.ai/code)