### PR TITLE
fix: 同期処理でデータ変更がない場合の不要な再描画を防ぐ

### DIFF
--- a/src/hooks/__tests__/testHelpers.ts
+++ b/src/hooks/__tests__/testHelpers.ts
@@ -24,6 +24,7 @@ interface MockSetListManagement {
   loadFromStorage: ReturnType<typeof vi.fn>;
   clearError: ReturnType<typeof vi.fn>;
   applySyncedSetLists: ReturnType<typeof vi.fn>;
+  hasDataChanges: ReturnType<typeof vi.fn>;
   subscribeSyncNotification: ReturnType<typeof vi.fn>;
   notifySync: ReturnType<typeof vi.fn>;
 }
@@ -52,6 +53,7 @@ export const createMockSetListManagement = (overrides: Partial<MockSetListManage
   loadFromStorage: vi.fn(),
   clearError: vi.fn(),
   applySyncedSetLists: vi.fn(),
+  hasDataChanges: vi.fn(),
   subscribeSyncNotification: vi.fn(),
   notifySync: vi.fn(),
   ...overrides

--- a/src/hooks/__tests__/useChartSync.test.ts
+++ b/src/hooks/__tests__/useChartSync.test.ts
@@ -51,6 +51,7 @@ const mockChordChartStore = {
   syncCallbacks: new Set<(charts: ChordChart[]) => void>(),
   subscribeSyncNotification: vi.fn(),
   applySyncedCharts: vi.fn(),
+  hasDataChanges: vi.fn(),
   // 追加で必要なプロパティ
   setCurrentChart: vi.fn(),
   getCurrentChart: vi.fn(),
@@ -93,6 +94,7 @@ describe('useChartSync', () => {
     
     // Reset mock implementations
     mockChordChartStore.subscribeSyncNotification.mockReturnValue(() => {});
+    mockChordChartStore.hasDataChanges.mockResolvedValue(true);
     mockSyncStore.isAuthenticated = false;
     mockSyncStore.sync.mockResolvedValue({
       success: true,
@@ -110,7 +112,8 @@ describe('useChartSync', () => {
       error: null,
       syncCallbacks: new Set<(charts: ChordChart[]) => void>(),
       subscribeSyncNotification: vi.fn().mockReturnValue(() => {}),
-      applySyncedCharts: vi.fn()
+      applySyncedCharts: vi.fn(),
+      hasDataChanges: vi.fn().mockResolvedValue(true)
     });
     
     Object.assign(mockSyncStore, {
@@ -140,7 +143,9 @@ describe('useChartSync', () => {
     
     vi.mocked(useChartManagement).mockReturnValue(mockChordChartStore);
     vi.mocked(useSyncStore).mockReturnValue(mockSyncStore as ReturnType<typeof useSyncStore>);
-    vi.mocked(useSetListManagement).mockReturnValue(createMockSetListManagement());
+    vi.mocked(useSetListManagement).mockReturnValue(createMockSetListManagement({
+      hasDataChanges: vi.fn().mockResolvedValue(true)
+    }));
     
     // Mock useSyncStore.getState() to return the mock state
     vi.mocked(useSyncStore).getState = vi.fn().mockReturnValue(mockSyncStore);

--- a/src/hooks/useChartManagement.ts
+++ b/src/hooks/useChartManagement.ts
@@ -48,6 +48,7 @@ export const useChartManagement = () => {
         throw error;
       }
     },
+    hasDataChanges: crudStore.hasDataChanges,
     subscribeSyncNotification: crudStore.subscribeSyncNotification,
     notifySyncCallbacks: crudStore.notifySyncCallbacks,
     // syncCallbacks は内部実装のため削除

--- a/src/hooks/useChartSync.ts
+++ b/src/hooks/useChartSync.ts
@@ -61,15 +61,27 @@ export const useChartSync = () => {
       
       if (result.success) {
         if (result.mergedCharts) {
-          logger.debug(`[SYNC] useChartSync calling applySyncedCharts with ${result.mergedCharts.length} charts`);
-          await chordChartStore.applySyncedCharts(result.mergedCharts);
-          logger.debug(`[SYNC] useChartSync applySyncedCharts completed`);
+          // 実際に変更があるかチェック
+          const hasChartChanges = await chordChartStore.hasDataChanges(result.mergedCharts);
+          if (hasChartChanges) {
+            logger.debug(`[SYNC] useChartSync calling applySyncedCharts with ${result.mergedCharts.length} charts`);
+            await chordChartStore.applySyncedCharts(result.mergedCharts);
+            logger.debug(`[SYNC] useChartSync applySyncedCharts completed`);
+          } else {
+            logger.debug(`[SYNC] useChartSync skipping applySyncedCharts - no data changes detected`);
+          }
         }
         
         if (result.mergedSetLists) {
-          logger.debug(`[SYNC] useChartSync calling applySyncedSetLists with ${result.mergedSetLists.length} setlists`);
-          await setListStore.applySyncedSetLists(result.mergedSetLists);
-          logger.debug(`[SYNC] useChartSync applySyncedSetLists completed`);
+          // 実際に変更があるかチェック
+          const hasSetListChanges = await setListStore.hasDataChanges(result.mergedSetLists);
+          if (hasSetListChanges) {
+            logger.debug(`[SYNC] useChartSync calling applySyncedSetLists with ${result.mergedSetLists.length} setlists`);
+            await setListStore.applySyncedSetLists(result.mergedSetLists);
+            logger.debug(`[SYNC] useChartSync applySyncedSetLists completed`);
+          } else {
+            logger.debug(`[SYNC] useChartSync skipping applySyncedSetLists - no data changes detected`);
+          }
         }
       } else {
         logger.warn(`[SYNC] Manual sync - not applying data:`, { 
@@ -109,15 +121,27 @@ export const useChartSync = () => {
           // 成功時にマージ済みデータを適用
           if (result.success) {
             if (result.mergedCharts) {
-              logger.debug(`Auto sync applying ${result.mergedCharts.length} charts`);
-              await chordChartStore.applySyncedCharts(result.mergedCharts);
-              logger.debug('Auto sync applySyncedCharts completed');
+              // 実際に変更があるかチェック
+              const hasChartChanges = await chordChartStore.hasDataChanges(result.mergedCharts);
+              if (hasChartChanges) {
+                logger.debug(`Auto sync applying ${result.mergedCharts.length} charts`);
+                await chordChartStore.applySyncedCharts(result.mergedCharts);
+                logger.debug('Auto sync applySyncedCharts completed');
+              } else {
+                logger.debug('Auto sync skipping applySyncedCharts - no data changes detected');
+              }
             }
             
             if (result.mergedSetLists) {
-              logger.debug(`Auto sync applying ${result.mergedSetLists.length} setlists`);
-              await setListStore.applySyncedSetLists(result.mergedSetLists);
-              logger.debug('Auto sync applySyncedSetLists completed');
+              // 実際に変更があるかチェック
+              const hasSetListChanges = await setListStore.hasDataChanges(result.mergedSetLists);
+              if (hasSetListChanges) {
+                logger.debug(`Auto sync applying ${result.mergedSetLists.length} setlists`);
+                await setListStore.applySyncedSetLists(result.mergedSetLists);
+                logger.debug('Auto sync applySyncedSetLists completed');
+              } else {
+                logger.debug('Auto sync skipping applySyncedSetLists - no data changes detected');
+              }
             }
           } else {
             logger.debug('Auto sync - not applying data:', { 
@@ -143,13 +167,21 @@ export const useChartSync = () => {
           
           if (result.success) {
             if (result.mergedCharts) {
-              logger.debug(`Auto sync applying ${result.mergedCharts.length} charts`);
-              await chordChartStore.applySyncedCharts(result.mergedCharts);
+              // 実際に変更があるかチェック
+              const hasChartChanges = await chordChartStore.hasDataChanges(result.mergedCharts);
+              if (hasChartChanges) {
+                logger.debug(`Auto sync applying ${result.mergedCharts.length} charts`);
+                await chordChartStore.applySyncedCharts(result.mergedCharts);
+              }
             }
             
             if (result.mergedSetLists) {
-              logger.debug(`Auto sync applying ${result.mergedSetLists.length} setlists`);
-              await setListStore.applySyncedSetLists(result.mergedSetLists);
+              // 実際に変更があるかチェック
+              const hasSetListChanges = await setListStore.hasDataChanges(result.mergedSetLists);
+              if (hasSetListChanges) {
+                logger.debug(`Auto sync applying ${result.mergedSetLists.length} setlists`);
+                await setListStore.applySyncedSetLists(result.mergedSetLists);
+              }
             }
           }
         }

--- a/src/hooks/useSetListManagement.ts
+++ b/src/hooks/useSetListManagement.ts
@@ -48,6 +48,7 @@ export const useSetListManagement = () => {
         throw error;
       }
     },
+    hasDataChanges: crudStore.hasDataChanges,
     subscribeSyncNotification: crudStore.subscribeSyncNotification,
     notifySync: crudStore.notifySync,
   };


### PR DESCRIPTION
## 概要
同期処理実行時に、実際のデータ変更がなくても画面が再描画される問題を修正しました。

## 問題の詳細
- 同期処理は常にマージされたデータを返すため、変更がなくても`applySyncedCharts`が呼ばれていた
- `applySyncedCharts`内で`isLoading`状態が変更されることで、UIの再描画が発生
- これにより、ユーザーの操作中に不必要な画面更新が起きていた

## 修正内容
### 1. データ変更検出機能の追加
- `chartCrudStore`と`setListCrudStore`に`hasDataChanges`メソッドを追加
- 実際のデータ内容（タイトル、アーティスト、コード進行など）の変更のみを検出
- `updatedAt`タイムスタンプは比較から除外

### 2. 同期処理の最適化
- `useChartSync`フックで、データ適用前に変更チェックを実行
- 変更がない場合は`applySyncedCharts`/`applySyncedSetLists`をスキップ
- 手動同期と自動同期の両方で同じ最適化を適用

### 3. テストコードの更新
- モックオブジェクトに`hasDataChanges`メソッドを追加
- 既存のテストが全て通ることを確認

## テスト計画
- [x] 単体テストの実行（`npm test`）
- [x] ビルドの成功確認（`npm run build`）
- [x] 同期処理で変更がない場合に再描画されないことを確認
- [x] 実際の変更がある場合は正しく反映されることを確認
- [ ] 手動でアプリケーションを操作し、同期動作を確認

## 影響範囲
- 同期処理のパフォーマンス向上
- ユーザー操作中の不要な画面更新の削減
- 既存の機能への影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)