### PR TITLE
拍子に応じたデフォルト拍数の自動設定と12/8拍子のサポート

### DIFF
--- a/src/components/BasicInfoEditor.tsx
+++ b/src/components/BasicInfoEditor.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import type { ChordChart } from '../types';
 import TransposeConfirmDialog from './TransposeConfirmDialog';
 import { transposeChart } from '../utils/transpose';
+import { COMMON_TIME_SIGNATURES } from '../utils/musicConstants';
 
 interface BasicInfoEditorProps {
   chart: ChordChart;
@@ -159,10 +160,9 @@ const BasicInfoEditor: React.FC<BasicInfoEditorProps> = ({ chart, onUpdate, onTr
             onChange={(e) => handleFormChange('timeSignature', e.target.value)}
             className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#85B0B7]"
           >
-            <option value="4/4">4/4</option>
-            <option value="3/4">3/4</option>
-            <option value="2/4">2/4</option>
-            <option value="6/8">6/8</option>
+            {COMMON_TIME_SIGNATURES.map(sig => (
+              <option key={sig} value={sig}>{sig}</option>
+            ))}
           </select>
         </div>
       </div>

--- a/src/hooks/__tests__/useChordOperations.test.ts
+++ b/src/hooks/__tests__/useChordOperations.test.ts
@@ -83,7 +83,7 @@ describe('useChordOperations', () => {
     // 新しいコードの基本プロパティを確認（idは動的生成されるため除外）
     expect(newChord.name).toBe('');
     expect(newChord.root).toBe('');
-    expect(newChord.duration).toBeUndefined();
+    expect(newChord.duration).toBe(4); // セクションのbeatsPerBar（4）がデフォルトとして設定される
     expect(newChord.memo).toBe('');
     expect(newChord.id).toBeDefined(); // idが存在することを確認
   });

--- a/src/hooks/__tests__/useSectionOperations.test.ts
+++ b/src/hooks/__tests__/useSectionOperations.test.ts
@@ -156,7 +156,7 @@ describe('useSectionOperations', () => {
       result.current.replaceChordProgression('section-1', 'C G');
     });
 
-    expect(mockTextToChords).toHaveBeenCalledWith('C G');
+    expect(mockTextToChords).toHaveBeenCalledWith('C G', 4); // セクションのbeatsPerBar（4）が渡される
     expect(mockOnUpdateChart).toHaveBeenCalledWith({
       ...mockChart,
       sections: [

--- a/src/hooks/useChordOperations.ts
+++ b/src/hooks/useChordOperations.ts
@@ -22,10 +22,14 @@ export const useChordOperations = ({
 }: UseChordOperationsProps) => {
 
   const addChordToSection = (sectionId: string) => {
+    // 拍子に応じてデフォルトの拍数を決定
+    const section = chart.sections?.find(s => s.id === sectionId);
+    const defaultDuration = section?.beatsPerBar || 4;
+    
     const newChord: Chord = toDisplayChord({
       name: '',
       root: '',
-      duration: undefined,
+      duration: defaultDuration,
       memo: ''
     });
     
@@ -65,9 +69,10 @@ export const useChordOperations = ({
       return;
     }
     
-    // 既存のコードの拍数をデフォルトとして使用
-    const currentChord = chart.sections?.find(s => s.id === sectionId)?.chords[chordIndex];
-    const defaultDuration = currentChord?.duration || 4;
+    // 既存のコードの拍数をデフォルトとして使用、なければセクションの拍子から
+    const section = chart.sections?.find(s => s.id === sectionId);
+    const currentChord = section?.chords[chordIndex];
+    const defaultDuration = currentChord?.duration || section?.beatsPerBar || 4;
     
     const parsed = parseChordInput(value, defaultDuration);
     if (!parsed) {

--- a/src/hooks/useSectionOperations.ts
+++ b/src/hooks/useSectionOperations.ts
@@ -86,7 +86,11 @@ export const useSectionOperations = ({
   const replaceChordProgression = (sectionId: string, text: string) => {
     if (!text.trim()) return;
     
-    const chords = textToChords(text);
+    // セクションの拍子からデフォルト拍数を取得
+    const section = chart.sections?.find(s => s.id === sectionId);
+    const defaultDuration = section?.beatsPerBar || 4;
+    
+    const chords = textToChords(text, defaultDuration);
     if (chords.length === 0) return;
 
     const updatedChart = {

--- a/src/utils/__tests__/chordCreation.test.ts
+++ b/src/utils/__tests__/chordCreation.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { createNewChordChart, createEmptySection, createEmptyChordChart } from '../chordCreation';
+
+describe('chordCreation', () => {
+  describe('createEmptySection', () => {
+    it('4/4拍子の場合、beatsPerBarが4になる', () => {
+      const section = createEmptySection('Intro', '4/4');
+      expect(section.beatsPerBar).toBe(4);
+      expect(section.name).toBe('Intro');
+    });
+
+    it('3/4拍子の場合、beatsPerBarが3になる', () => {
+      const section = createEmptySection('Verse', '3/4');
+      expect(section.beatsPerBar).toBe(3);
+      expect(section.name).toBe('Verse');
+    });
+
+    it('6/8拍子の場合、beatsPerBarが6になる', () => {
+      const section = createEmptySection('Chorus', '6/8');
+      expect(section.beatsPerBar).toBe(6);
+      expect(section.name).toBe('Chorus');
+    });
+
+    it('12/8拍子の場合、beatsPerBarが12になる', () => {
+      const section = createEmptySection('Bridge', '12/8');
+      expect(section.beatsPerBar).toBe(12);
+      expect(section.name).toBe('Bridge');
+    });
+
+    it('デフォルトのパラメータで作成した場合、4/4拍子になる', () => {
+      const section = createEmptySection();
+      expect(section.beatsPerBar).toBe(4);
+      expect(section.name).toBe('セクション');
+    });
+  });
+
+  describe('createEmptyChordChart', () => {
+    it('デフォルトのコード譜を作成する', () => {
+      const chart = createEmptyChordChart();
+      expect(chart.title).toBe('新しいコード譜');
+      expect(chart.timeSignature).toBe('4/4');
+      expect(chart.sections).toHaveLength(1);
+      expect(chart.sections[0].name).toBe('イントロ');
+      expect(chart.sections[0].beatsPerBar).toBe(4);
+    });
+  });
+
+  describe('createNewChordChart', () => {
+    it('指定した拍子でセクションが作成される（4/4）', () => {
+      const chart = createNewChordChart({
+        title: 'Test Chart',
+        timeSignature: '4/4'
+      });
+      
+      expect(chart.title).toBe('Test Chart');
+      expect(chart.timeSignature).toBe('4/4');
+      expect(chart.sections).toHaveLength(1);
+      expect(chart.sections[0].beatsPerBar).toBe(4);
+    });
+
+    it('指定した拍子でセクションが作成される（3/4）', () => {
+      const chart = createNewChordChart({
+        title: 'Waltz',
+        timeSignature: '3/4'
+      });
+      
+      expect(chart.timeSignature).toBe('3/4');
+      expect(chart.sections[0].beatsPerBar).toBe(3);
+    });
+
+    it('指定した拍子でセクションが作成される（6/8）', () => {
+      const chart = createNewChordChart({
+        title: 'Compound Time',
+        timeSignature: '6/8'
+      });
+      
+      expect(chart.timeSignature).toBe('6/8');
+      expect(chart.sections[0].beatsPerBar).toBe(6);
+    });
+
+    it('指定した拍子でセクションが作成される（12/8）', () => {
+      const chart = createNewChordChart({
+        title: 'Blues',
+        timeSignature: '12/8'
+      });
+      
+      expect(chart.timeSignature).toBe('12/8');
+      expect(chart.sections[0].beatsPerBar).toBe(12);
+    });
+
+    it('拍子を指定しない場合はデフォルトの4/4になる', () => {
+      const chart = createNewChordChart({
+        title: 'Default Time'
+      });
+      
+      expect(chart.timeSignature).toBe('4/4');
+      expect(chart.sections[0].beatsPerBar).toBe(4);
+    });
+
+    it('カスタムセクションが指定された場合はそれを使用する', () => {
+      const customSections = [
+        createEmptySection('Custom Section', '7/8')
+      ];
+      
+      const chart = createNewChordChart({
+        title: 'Custom',
+        timeSignature: '3/4',
+        sections: customSections
+      });
+      
+      expect(chart.sections).toBe(customSections);
+      // カスタムセクションが使われるので、chartのtimeSignatureとは関係なく7/8のbeatsPerBarになる
+      expect(chart.sections[0].beatsPerBar).toBe(7);
+    });
+
+    it('必須フィールドが正しく設定される', () => {
+      const chart = createNewChordChart({});
+      
+      expect(chart.id).toBeDefined();
+      expect(chart.createdAt).toBeInstanceOf(Date);
+      expect(chart.updatedAt).toBeInstanceOf(Date);
+      expect(chart.tempo).toBe(120);
+      expect(chart.key).toBe('C');
+    });
+
+    it('tempoが0の場合でも保持される', () => {
+      const chart = createNewChordChart({
+        tempo: 0
+      });
+      
+      expect(chart.tempo).toBe(0);
+    });
+
+    it('tempoが未定義の場合はデフォルト値が使用される', () => {
+      const chart = createNewChordChart({
+        tempo: undefined
+      });
+      
+      expect(chart.tempo).toBe(120);
+    });
+  });
+});

--- a/src/utils/chordCopyPaste.ts
+++ b/src/utils/chordCopyPaste.ts
@@ -7,16 +7,17 @@ import { v4 as uuidv4 } from 'uuid';
  * 文字列からコード進行をパースする
  * 
  * @param text - テキスト形式のコード進行
+ * @param defaultDuration - 拍数指定がない場合のデフォルト拍数
  * @returns コードの配列
  * 
  * サポートする形式:
- * - "C F G Am" (デフォルト4拍)
+ * - "C F G Am" (デフォルト拍数使用)
  * - "C[4] F[2] G[2] Am[4]" (拍数指定)
  * - "C F | G Am" (改行あり)
  * - "C[1.5] F[2.5]" (小数拍数)
  * - "E7(#9)[2] C7(b5)[4]" (テンションコード)
  */
-export const textToChords = (text: string): Chord[] => {
+export const textToChords = (text: string, defaultDuration: number = 4): Chord[] => {
   const chords: Chord[] = [];
   
   // 文字列を空白で分割
@@ -34,7 +35,7 @@ export const textToChords = (text: string): Chord[] => {
       });
     } else if (part.trim()) {
       // コード解析
-      const chord = parseChordText(part);
+      const chord = parseChordText(part, defaultDuration);
       if (chord) {
         chords.push(chord);
       }
@@ -48,10 +49,11 @@ export const textToChords = (text: string): Chord[] => {
  * 個別のコードテキストをパースする
  * 
  * @param text - コードテキスト (例: "Am[2]", "C7", "F#m", "E7(#9)[4]", "C/E[2]")
+ * @param defaultDuration - 拍数指定がない場合のデフォルト拍数
  * @returns パースされたコード、またはnull
  */
-const parseChordText = (text: string): Chord | null => {
-  const parsedChord = parseChordInput(text, 4);
+const parseChordText = (text: string, defaultDuration: number = 4): Chord | null => {
+  const parsedChord = parseChordInput(text, defaultDuration);
   if (parsedChord) {
     return {
       ...parsedChord,

--- a/src/utils/chordCreation.ts
+++ b/src/utils/chordCreation.ts
@@ -31,14 +31,18 @@ export const createNewChordChart = (
   const now = new Date();
   const empty = createEmptyChordChart();
   
+  // ユーザーが選択した拍子を使用してセクションを作成
+  const timeSignature = data.timeSignature || empty.timeSignature;
+  const sections = data.sections || [createEmptySection('イントロ', timeSignature)];
+  
   return {
     id: uuidv4(),
     ...empty,
     ...data,
     // tempoが未定義の場合はデフォルト値を使用
     tempo: data.tempo !== undefined ? data.tempo : empty.tempo,
-    // sectionsが未定義の場合はデフォルトセクションを使用
-    sections: data.sections || empty.sections,
+    // 正しい拍子で作成されたセクションを使用
+    sections,
     createdAt: now,
     updatedAt: now
   };


### PR DESCRIPTION
## 概要
拍子設定に応じてコード入力時のデフォルト拍数を自動的に設定する機能を実装しました。
また、12/8拍子が選択できない問題も修正しました。

## 変更内容
### 1. 拍子選択の問題修正
- `BasicInfoEditor`コンポーネントで12/8拍子が選択できない問題を修正
- ハードコードされた拍子リストを`COMMON_TIME_SIGNATURES`定数に置き換え

### 2. デフォルト拍数の自動設定
- **手入力時**: 新しいコード追加時、セクションの`beatsPerBar`をデフォルト拍数として使用
- **一括入力時**: テキストから入力する際、拍数指定がない場合はセクションの`beatsPerBar`を使用
- **新規作成時**: 選択した拍子に基づいて初期セクションの`beatsPerBar`を正しく設定

### 3. テストの追加と更新
- `chordCreation.test.ts`を新規作成し、拍子設定の動作を包括的にテスト
- 既存のテストを更新して新しい動作に対応

## 動作例
- 6/8拍子を選択 → デフォルト拍数6
- 3/4拍子を選択 → デフォルト拍数3
- 12/8拍子を選択 → デフォルト拍数12
- 4/4拍子を選択 → デフォルト拍数4（従来通り）

## テスト計画
- [x] 全ユニットテストが成功することを確認
- [x] lint/buildが成功することを確認
- [ ] 各拍子でのコード入力動作を手動確認
- [ ] 新規作成時の拍子設定が正しく反映されることを確認
- [ ] 既存のコード譜の動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)