### PR TITLE
fix: チャート編集画面のセクションドラッグハンドルのUI改善

### DIFF
--- a/e2e/tests/drag-drop.spec.ts
+++ b/e2e/tests/drag-drop.spec.ts
@@ -22,7 +22,9 @@ test.describe('Nekogata Score Manager - ドラッグ&ドロップ機能テスト
 
   test('コード順序変更のドラッグ&ドロップが正確に動作する', async ({ page, browserName }) => {
     // WebKit系ブラウザでは@dnd-kitの互換性問題により一時的にスキップ
-    test.skip(browserName === 'webkit', 'WebKit系ブラウザでは@dnd-kitドラッグ操作に互換性問題があります');
+    if (browserName === 'webkit') {
+      test.skip(true, 'WebKit系ブラウザでは@dnd-kitドラッグ操作に互換性問題があります');
+    }
     
     const homePage = new HomePage(page);
     const chartFormPage = new ChordChartFormPage(page);

--- a/src/components/ChordChartEditor.tsx
+++ b/src/components/ChordChartEditor.tsx
@@ -125,7 +125,7 @@ const ChordChartEditor: React.FC<ChordChartEditorProps> = ({ chart, onSave, onCa
 
   return (
     <div className="h-full bg-white overflow-y-auto" data-testid="chart-editor">
-      <div className="p-6">
+      <div className="p-6 pl-16">
         {/* Header */}
         <div className="mb-6 flex justify-between items-center">
           <h2 className="text-2xl font-bold text-slate-900" data-testid="editor-title">{chart.title || '無題のコード譜'} - 編集</h2>

--- a/src/components/SortableSectionItem.tsx
+++ b/src/components/SortableSectionItem.tsx
@@ -28,11 +28,11 @@ const SortableSectionItem: React.FC<SortableSectionItemProps> = ({ id, children 
       <div className="relative">
         <div
           {...listeners}
-          className="absolute -left-8 top-0 w-6 h-full flex items-center justify-center cursor-move hover:bg-slate-100 rounded"
+          className="absolute -left-12 top-0 w-10 h-full flex items-center justify-center cursor-move hover:bg-slate-100 rounded"
           title="ドラッグして並び替え"
         >
           <svg
-            className="w-4 h-4 text-slate-400"
+            className="w-6 h-6 text-slate-400"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"


### PR DESCRIPTION
## 概要
チャート編集画面でセクションのドラッグ&ドロップハンドルが小さく、操作しづらい問題を改善しました。

## 変更内容
- ドラッグハンドルの横幅を24px(w-6)から40px(w-10)に拡大
- ハンドルアイコンのサイズを16px(w-4 h-4)から24px(w-6 h-6)に拡大  
- ハンドルの位置を左に8px移動（-left-8から-left-12）
- ChordChartEditorに左パディング(pl-16)を追加して画面端との余白を確保
- WebKitブラウザでのE2Eテストスキップ処理を修正

## スクリーンショット
変更前: ドラッグハンドルが小さく、画面左端に張り付いていた
変更後: より大きなドラッグハンドルで、画面端に適切な余白がある

## テスト計画
- [x] `npm run lint` - Lintエラーなし
- [x] `npm run build` - ビルド成功  
- [x] `npm test` - 全ユニットテスト合格
- [x] `npm run test:e2e` - 全E2Eテスト合格（WebKitでのドラッグテストは既知の問題でスキップ）
- [x] デスクトップブラウザでドラッグハンドルの動作確認
- [ ] タッチデバイスでドラッグハンドルの操作性確認

🤖 Generated with [Claude Code](https://claude.ai/code)