### PR TITLE
fix: セットリスト画面のドラッグハンドルUIを統一

### DIFF
--- a/src/components/SetListChartItem.tsx
+++ b/src/components/SetListChartItem.tsx
@@ -42,22 +42,34 @@ const SetListChartItem: React.FC<SetListChartItemProps> = ({
       <div
         ref={setNodeRef}
         style={style}
-        className={`p-3 bg-slate-50 rounded-md ${isDragging ? 'opacity-50' : ''}`}
+        className={`py-3 pr-3 pl-1 bg-slate-50 rounded-md ${isDragging ? 'opacity-50' : ''}`}
         data-testid={`setlist-chart-item-${index}`}
       >
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1">
+          <div
+            className="cursor-grab active:cursor-grabbing text-slate-300 hover:text-slate-400 w-6 h-full flex items-center justify-center"
+            {...attributes}
+            {...listeners}
+          >
+            <svg
+              className="w-4 h-4 text-slate-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 8h16M4 16h16"
+              />
+            </svg>
+          </div>
           <span className="text-xs text-slate-400 min-w-[24px]">
             {index + 1}.
           </span>
           <div className="text-sm text-slate-400 flex-1">
             (削除された楽譜)
-          </div>
-          <div
-            className="cursor-grab active:cursor-grabbing text-slate-300 hover:text-slate-400 p-1"
-            {...attributes}
-            {...listeners}
-          >
-            ⋮⋮
           </div>
         </div>
       </div>
@@ -68,13 +80,33 @@ const SetListChartItem: React.FC<SetListChartItemProps> = ({
     <div
       ref={setNodeRef}
       style={style}
-      className={`p-3 bg-slate-50 hover:bg-slate-100 rounded-md transition-colors cursor-pointer ${
+      className={`py-3 pr-3 pl-1 bg-slate-50 hover:bg-slate-100 rounded-md transition-colors cursor-pointer ${
         isDragging ? 'opacity-50 bg-slate-200' : ''
       }`}
       onClick={() => onChartClick(chartId)}
       data-testid={`setlist-chart-item-${index}`}
     >
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1">
+        <div
+          className="cursor-grab active:cursor-grabbing text-slate-400 hover:text-slate-500 w-6 h-full flex items-center justify-center"
+          {...attributes}
+          {...listeners}
+          onClick={(e) => e.stopPropagation()} // ドラッグハンドルクリック時に楽譜選択を防ぐ
+        >
+          <svg
+            className="w-4 h-4 text-slate-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 8h16M4 16h16"
+            />
+          </svg>
+        </div>
         <span className="text-xs text-slate-500 min-w-[24px] font-medium">
           {index + 1}.
         </span>
@@ -90,14 +122,6 @@ const SetListChartItem: React.FC<SetListChartItemProps> = ({
           <p className="text-xs text-slate-500 mt-1">
             Artist: {chart.artist}
           </p>
-        </div>
-        <div
-          className="cursor-grab active:cursor-grabbing text-slate-400 hover:text-slate-500 p-1"
-          {...attributes}
-          {...listeners}
-          onClick={(e) => e.stopPropagation()} // ドラッグハンドルクリック時に楽譜選択を防ぐ
-        >
-          ⋮⋮
         </div>
       </div>
     </div>

--- a/src/components/__tests__/SetListChartItem.test.tsx
+++ b/src/components/__tests__/SetListChartItem.test.tsx
@@ -34,7 +34,7 @@ describe('SetListChartItem', () => {
   };
 
   it('楽譜が存在する場合、正しく表示される', () => {
-    renderWithDndContext(
+    const { container } = renderWithDndContext(
       <SetListChartItem
         index={0}
         chart={mockChart}
@@ -47,7 +47,10 @@ describe('SetListChartItem', () => {
     expect(screen.getByText('Test Song')).toBeInTheDocument();
     expect(screen.getByText('(Key: C)')).toBeInTheDocument();
     expect(screen.getByText('Artist: Test Artist')).toBeInTheDocument();
-    expect(screen.getByText('⋮⋮')).toBeInTheDocument();
+    // SVGアイコンが存在することを確認
+    const dragHandle = container.querySelector('[role="button"][aria-roledescription="sortable"]');
+    expect(dragHandle).toBeInTheDocument();
+    expect(dragHandle).toHaveClass('cursor-grab');
   });
 
   it('楽譜をクリックするとonChartClickが呼ばれる', () => {
@@ -67,7 +70,7 @@ describe('SetListChartItem', () => {
   });
 
   it('ドラッグハンドルをクリックしてもonChartClickが呼ばれない', () => {
-    renderWithDndContext(
+    const { container } = renderWithDndContext(
       <SetListChartItem
         index={0}
         chart={mockChart}
@@ -76,14 +79,14 @@ describe('SetListChartItem', () => {
       />
     );
 
-    const dragHandle = screen.getByText('⋮⋮');
-    fireEvent.click(dragHandle);
+    const dragHandle = container.querySelector('[role="button"][aria-roledescription="sortable"]');
+    fireEvent.click(dragHandle!);
 
     expect(mockOnChartClick).not.toHaveBeenCalled();
   });
 
   it('削除された楽譜の場合、適切なメッセージが表示される', () => {
-    renderWithDndContext(
+    const { container } = renderWithDndContext(
       <SetListChartItem
         index={1}
         chart={null}
@@ -94,7 +97,10 @@ describe('SetListChartItem', () => {
 
     expect(screen.getByText('2.')).toBeInTheDocument();
     expect(screen.getByText('(削除された楽譜)')).toBeInTheDocument();
-    expect(screen.getByText('⋮⋮')).toBeInTheDocument();
+    // SVGアイコンが存在することを確認
+    const dragHandle = container.querySelector('[role="button"][aria-roledescription="sortable"]');
+    expect(dragHandle).toBeInTheDocument();
+    expect(dragHandle).toHaveClass('cursor-grab');
   });
 
   it('削除された楽譜をクリックしてもonChartClickが呼ばれない', () => {
@@ -143,7 +149,7 @@ describe('SetListChartItem', () => {
   });
 
   it('ドラッグ可能な要素として設定されている', () => {
-    renderWithDndContext(
+    const { container } = renderWithDndContext(
       <SetListChartItem
         index={0}
         chart={mockChart}
@@ -156,7 +162,8 @@ describe('SetListChartItem', () => {
     expect(chartItem).toBeInTheDocument();
     
     // ドラッグハンドルが存在することを確認
-    const dragHandle = screen.getByText('⋮⋮');
+    const dragHandle = container.querySelector('[role="button"][aria-roledescription="sortable"]');
+    expect(dragHandle).toBeInTheDocument();
     expect(dragHandle).toHaveClass('cursor-grab');
   });
 });


### PR DESCRIPTION
## 概要
セットリスト一覧画面とコード譜編集画面のドラッグ&ドロップハンドルの位置とスタイルに一貫性がない問題を修正しました。

## 変更内容
- セットリスト一覧のドラッグハンドルを右側から左側に移動
- ハンドルアイコンをテキスト（⋮⋮）から横線2本のSVGアイコンに変更
- セットリストのハンドルサイズを小さく調整（幅: w-6、アイコン: w-4 h-4）
- 左側のパディングを最小化（pl-1）してコンパクトに
- 関連するテストを修正

## テスト計画
- [x] ユニットテストが全て通過することを確認
- [x] E2Eテストが全て通過することを確認
- [x] `npm run lint`でエラーがないことを確認
- [x] `npm run build`でビルドが成功することを確認
- [ ] セットリスト画面でドラッグ&ドロップが正常に動作することを確認
- [ ] コード譜編集画面と同じUI体験であることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)