### PR TITLE
fix: コード譜編集画面のドラッグハンドルを拡大

### DIFF
--- a/e2e/pages/ChartEditorPage.ts
+++ b/e2e/pages/ChartEditorPage.ts
@@ -258,8 +258,8 @@ export class ChartEditorPage {
     const sourceChord = await this.getActualChordElement(fromSectionIndex, fromChordIndex);
     const targetChord = await this.getActualChordElement(toSectionIndex, toChordIndex);
     
-    // ドラッグハンドルを取得（⋮⋮ボタン）
-    const dragHandle = sourceChord.locator('button[title="ドラッグして移動"]');
+    // ドラッグハンドルを取得（ヘッダー全体がドラッグ可能）
+    const dragHandle = sourceChord.locator('div.cursor-grab').first();
     
     console.log(`Dragging chord from section ${fromSectionIndex}, index ${fromChordIndex} to section ${toSectionIndex}, index ${toChordIndex}`);
     

--- a/e2e/tests/drag-drop.spec.ts
+++ b/e2e/tests/drag-drop.spec.ts
@@ -189,10 +189,10 @@ test.describe('Nekogata Score Manager - ドラッグ&ドロップ機能テスト
     const chordCount = await chordItems.count();
     expect(chordCount).toBeGreaterThanOrEqual(2);
 
-    // 各コードアイテムにドラッグハンドルが存在することを確認
+    // 各コードアイテムにドラッグハンドル（ヘッダー部分）が存在することを確認
     for (let i = 0; i < Math.min(chordCount, 2); i++) {
       const chordItem = chordItems.nth(i);
-      const dragHandle = chordItem.locator('button[title="ドラッグして移動"]');
+      const dragHandle = chordItem.locator('div.cursor-grab').first();
       const dragHandleExists = await dragHandle.count() > 0;
       expect(dragHandleExists).toBe(true);
     }

--- a/src/components/SortableChordItem.tsx
+++ b/src/components/SortableChordItem.tsx
@@ -178,17 +178,19 @@ const SortableChordItem: React.FC<SortableChordItemProps> = ({
         }
       }}
     >
-      <div className="flex justify-between items-center mb-1">
+      <div 
+        className="flex justify-between items-center mb-1 cursor-grab active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+      >
         <span className="text-xs text-slate-500">#{chordIndex + 1}</span>
         <div className="flex gap-1">
-          <button
-            {...attributes}
-            {...listeners}
-            className="text-slate-400 hover:text-slate-600 text-xs cursor-grab active:cursor-grabbing"
+          <span
+            className="text-slate-400 hover:text-slate-600 text-xs"
             title="ドラッグして移動"
           >
             ⋮⋮
-          </button>
+          </span>
           {isSelected && (
             <span className="text-[#85B0B7] text-xs">
               ✓

--- a/src/components/__tests__/ChordChartEditor-DragDrop.test.tsx
+++ b/src/components/__tests__/ChordChartEditor-DragDrop.test.tsx
@@ -144,9 +144,9 @@ describe('ChordChartEditor - Drag & Drop', () => {
       />
     );
 
-    // ドラッグハンドルボタンが存在し、正しいクラスが適用されていることを確認
+    // ドラッグハンドルが存在することを確認（ヘッダー全体がドラッグ可能になっている）
     const dragHandles = screen.getAllByTitle('ドラッグして移動');
-    expect(dragHandles[0]).toHaveClass('cursor-grab', 'active:cursor-grabbing');
+    expect(dragHandles[0]).toBeInTheDocument();
   });
 
   it('改行マーカーにもドラッグハンドルが表示される', () => {


### PR DESCRIPTION
## 概要
コード譜編集画面で、コードカードのドラッグ&ドロップのハンドルが小さく操作しづらかったため、ドラッグ可能エリアをヘッダー全体に拡大しました。

## 変更内容
- 🎯 ドラッグハンドルボタン（⋮⋮）だけでなく、コードカードのヘッダー全体をドラッグ可能に変更
- 🎨 `<button>`要素を`<span>`に変更し、親の`<div>`要素に`cursor-grab`クラスとドラッグ属性を付与
- ✅ ユニットテストとE2Eテストのセレクタを更新

## テスト計画
- [x] ユニットテスト全て合格
- [x] E2Eテスト全て合格
- [x] Lint通過
- [x] ビルド成功
- [x] コード譜編集画面でドラッグ&ドロップの動作確認

## スクリーンショット
変更前: ドラッグハンドルボタン（⋮⋮）のみがドラッグ可能
変更後: ヘッダー全体（コード番号とアクションボタンを含む行）がドラッグ可能

🤖 Generated with [Claude Code](https://claude.ai/code)